### PR TITLE
Fix package name collisions and add tests

### DIFF
--- a/pkg/checkers/base/base.go
+++ b/pkg/checkers/base/base.go
@@ -508,21 +508,10 @@ func createErrAndPkgMap(mergedPacks []*types.PkgResult) map[string][]string {
 }
 
 func resultForSamePackage(pkg1, pkg2 *types.PkgResult) bool {
-	if pkg1.Package.Name != "" && pkg2.Package.Name != "" {
-		if pkg1.Package.Name == pkg2.Package.Name {
-			return true
-		} else {
-			return false
-		}
+	if pkg1.Package.SpdxID == "" && pkg2.Package.SpdxID == "" {
+		return pkg1.Package.Name == pkg2.Package.Name
 	}
-	if pkg1.Package.SpdxID != "" && pkg2.Package.SpdxID != "" {
-		if pkg1.Package.SpdxID == pkg2.Package.SpdxID {
-			return true
-		} else {
-			return false
-		}
-	}
-	return false
+	return pkg1.Package.SpdxID == pkg2.Package.SpdxID
 }
 
 func mergePkgResults(packs []*types.PkgResult) []*types.PkgResult {


### PR DESCRIPTION
Many of our SBOMs have packages with the same names, and this was causing incorrect results. We can rely purely on`SPDXID` to identify equal packages because `SPDXID` should be unique. The fallback to `Package.Name` in `resultForSamePackage` is only added because some tests (which will probably be eventually removed) don't set the `SPDXID`.