### PR TITLE
Refactor and test the check results API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sbom-conformance
 
-A tool to check the conformance of SBOMs compared to Googles internal spec, the EO requirements and the SPDX requirements.
+A tool to check the conformance of SBOMs to Google's internal spec, the NTIA Minimum elements specification, and the SPDX requirements.
 
 > [!IMPORTANT]  
 > This library is being developed. It's not recommended to use it yet.
@@ -63,28 +63,28 @@ Get a structured summary of the SBOM and the conformance checks.
 results.Summary
 ```
 
+##### Get top-level results
+
+Get the results of the top-level conformance checks.
+
+```go
+results.TopLevelChecks
+```
+
 ##### Get package results
 
-Gets structured results for the packages from the checks.
+There are two ways to get the results of the package-level conformance checks.
+
+Get conformance checks per-package:
 
 ```go
 results.PkgResults
 ```
 
-##### Get error results
-
-Gets the output of the conformance checks sorted by issues found.
+Get the conformance checks directly, with statistics on the number of passed packages.
 
 ```go
-results.PkgResults
-```
-
-##### ChecksInRun
-
-Gets a summary of the checks that were included in the run.
-
-```go
-results.ChecksInRun
+results.PackageLevelChecks
 ```
 
 ## main.go

--- a/pkg/checkers/eo/eo.go
+++ b/pkg/checkers/eo/eo.go
@@ -34,10 +34,6 @@ type EOChecker struct {
 func (eoChecker *EOChecker) InitChecks() {
 	topLevelChecks := []*types.TopLevelCheck{
 		{
-			Name: "Check that the SBOM has a version",
-			Impl: common.SBOMHasSPDXVersion,
-		},
-		{
 			Name: "Check that the SBOM has an SPDX version",
 			Impl: common.SBOMHasSPDXVersion,
 		},

--- a/pkg/checkers/types/output.go
+++ b/pkg/checkers/types/output.go
@@ -22,15 +22,43 @@ type SpecSummary struct {
 	TotalChecks  int `json:"totalChecks"`
 }
 
+type TopLevelCheckResult struct {
+	Name   string   `json:"name"`
+	Passed bool     `json:"passed"`
+	Specs  []string `json:"specs"`
+}
+
+type PackageLevelCheckResult struct {
+	Name              string   `json:"name"`
+	FailedPkgsPercent float32  `json:"failedPkgsPercent,omitempty"`
+	Specs             []string `json:"specs"`
+}
+
 // Output is the type we convert to json when we output the results.
 type Output struct {
-	TextSummary        string              `json:"textSummary"`
-	Summary            *Summary            `json:"summary"`
-	ErrsAndPacks       map[string][]string `json:"errsAndPacks,omitempty"`
-	PkgResults         []*PkgResult        `json:"pkgResults,omitempty"`
-	ChecksInRun        []*CheckSummary     `json:"checksInRun"`
-	TotalSBOMPackages  int                 `json:"totalSbomPackages"`
-	FailedSBOMPackages int                 `json:"failedSbomPackages"`
+	// TextSummary is a text summary of the conformance checks
+	TextSummary string `json:"textSummary"`
+
+	// Summary is a structured summary of the conformance checks
+	Summary *Summary `json:"summary"`
+
+	// TopLevelChecks is a list of the top-level checks that were run along with
+	// the specifications they are a part of and whether they passed or not.
+	TopLevelChecks []*TopLevelCheckResult `json:"topLevelChecks"`
+
+	// PackageLevelChecks a list of the package-checks that were run along with
+	// the specifications they are a part of and the number of packages they passed
+	// for.
+	PackageLevelChecks []*PackageLevelCheckResult `json:"packageLevelChecks"`
+
+	// PkgResults is a list of the packages in the SBOM, along with the conformance
+	// checks that each package failed.
+	PkgResults []*PkgResult `json:"pkgResults,omitempty"`
+
+	// ErrsAndPacks is a map of failed conformance checks to the names of the
+	// packages that failed them.
+	// TODO - does this need to exist?
+	ErrsAndPacks map[string][]string `json:"errsAndPacks,omitempty"`
 }
 
 type Summary struct {
@@ -42,13 +70,13 @@ type Summary struct {
 func OutputFromInput(pkgResults []*PkgResult,
 	errsAndPacks map[string][]string,
 	totalSBOMPkgs, failedSBOMackages int,
-	checksInRun []*CheckSummary,
+	topLevelChecks []*TopLevelCheckResult,
+	packageLevelChecks []*PackageLevelCheckResult,
 ) *Output {
 	return &Output{
 		PkgResults:         pkgResults,
 		ErrsAndPacks:       errsAndPacks,
-		TotalSBOMPackages:  totalSBOMPkgs,
-		FailedSBOMPackages: failedSBOMackages,
-		ChecksInRun:        checksInRun,
+		TopLevelChecks:     topLevelChecks,
+		PackageLevelChecks: packageLevelChecks,
 	}
 }


### PR DESCRIPTION
- The `ChecksInRun` field in the `Output` struct is replaced with `TopLevelChecks` and `PackageLevelChecks` because these two structs contain different data (a `Passed` boolean versus a `FailedPkgsPercent` floating point). This will also make testing easier. 
- An extraneous check in the EO spec is removed.
- A test suite (`TestEOTopLevelChecks`) is added to establish the current behavior for `Output.TopLevelChecks` for the EO specification. Whether this is correct w.r.t to the NTIA specification will be addressed in follow-up PRs.
- A test suite (`TestPackageLevelChecks`) is added to establish correctness for `Output.PackageLevelChecks`. Correctness of the checks themselves isn't established by this test, just the correctness of that API.
- `FailedSBOMPackages` and `FailedSBOMPackages` are removed from the `Output` struct because they are accessible in `Output.Summary`
- `internal/example/main.go` is modified to replace `ChecksInRun` with `TopLevelChecks` and `PackageLevelChecks`.

