### PR TITLE
Improve the text summary of the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sbom-conformance
 
-A tool to check the conformance of SBOMs to Google's internal spec, the NTIA Minimum elements specification, and the SPDX requirements.
+A tool to check the conformance of SBOMs to Google's internal spec, the NTIA Minimum Elements specification, and the SPDX requirements.
 
 > [!IMPORTANT]  
 > This library is being developed. It's not recommended to use it yet.

--- a/internal/example/main.go
+++ b/internal/example/main.go
@@ -169,7 +169,6 @@ func main() {
 	////                          ////
 	//////////////////////////////////
 
-	fmt.Println("Results")
 	numberOfFailedPkgs := checker.NumberOfSBOMPackages() - checker.NumberOfCompliantPackages()
 
 	if *flagTextSummary {

--- a/pkg/checkers/base/base.go
+++ b/pkg/checkers/base/base.go
@@ -384,16 +384,16 @@ func (checker *BaseChecker) TextSummary() string {
 		pkgLevelIssues := make([]string, 0)
 		for e, p := range checker.ErrsAndPacks {
 			var packageString string
-			if len(p) == 1 {
-				packageString = "package"
-			} else {
+			if checker.NumberOfSBOMPackages() > 1 {
 				packageString = "packages"
+			} else {
+				packageString = "package"
 			}
-			issue := fmt.Sprintf("%d/%d %s failed: %s",
+			issue := fmt.Sprintf("%s: %d/%d %s failed.",
+				e,
 				len(p),
 				checker.NumberOfSBOMPackages(),
-				packageString,
-				e)
+				packageString)
 			pkgLevelIssues = append(pkgLevelIssues, issue)
 		}
 		slices.Sort(pkgLevelIssues)

--- a/pkg/checkers/base/base.go
+++ b/pkg/checkers/base/base.go
@@ -344,52 +344,65 @@ func (checker *BaseChecker) isFailedTopLevelCheck(checkName string) bool {
 	return false
 }
 
-// This is mainly useful for demonstration-purposes.
 func (checker *BaseChecker) TextSummary() string {
-	failedSBOMackages := checker.NumberOfSBOMPackages() - checker.NumberOfCompliantPackages()
-	var sb strings.Builder
-	sb.WriteString(
-		fmt.Sprintf("Analyzed SBOM package with %d packages. ", checker.NumberOfSBOMPackages()),
-	)
-	sb.WriteString(
-		fmt.Sprintf("%d of these packages failed the conformance checks.\n", failedSBOMackages),
-	)
-	sb.WriteString("\nTop-level conformance issues:\n")
-	topLevelIssues := make([]string, 0)
-	for _, issue := range checker.TopLevelResults {
-		issue := fmt.Sprintf("%s. %s",
-			issue.ErrorMessage,
-			issue.NonConformantWithSpecs)
-		topLevelIssues = append(topLevelIssues, issue)
-	}
-	// Sort to make the slice deterministic (which is necessary for testing)
-	slices.Sort(topLevelIssues)
-	for _, topLevelIssue := range topLevelIssues {
-		sb.WriteString(topLevelIssue + "\n")
-	}
-	sb.WriteString("\nConformance issues in packages:\n")
+	var initialStringBuilder strings.Builder
+	initialStringBuilder.WriteString("Summary:\n")
+	sbWithTab := util.StringBuilderWithPrefixAndSuffix(&initialStringBuilder, "\t", "\n")
 
-	pkgLevelIssues := make([]string, 0)
-	for e, p := range checker.ErrsAndPacks {
-		var packageString string
-		if len(p) == 1 {
-			packageString = "package"
-		} else {
-			packageString = "packages"
+	// Summary
+	sbWithTab.Writef(
+		"Analyzed an SBOM with %d package(s). %d top-level conformance check(s)"+
+			" failed. %d package(s) had at least one failing conformance check.",
+		checker.NumberOfSBOMPackages(),
+		len(checker.TopLevelResults),
+		checker.NumberOfSBOMPackages()-checker.NumberOfCompliantPackages(),
+	)
+
+	// Enumerate the failed top-level checks.
+	if len(checker.TopLevelResults) > 0 {
+		initialStringBuilder.WriteString("\n")
+		sbWithTab.Writef("Top-level conformance issues:")
+		topLevelIssues := make([]string, 0)
+		for _, issue := range checker.TopLevelResults {
+			issue := fmt.Sprintf("%s. %s",
+				issue.ErrorMessage,
+				issue.NonConformantWithSpecs)
+			topLevelIssues = append(topLevelIssues, issue)
 		}
-		issue := fmt.Sprintf("%d/%d %s failed: %s",
-			len(p),
-			checker.NumberOfSBOMPackages(),
-			packageString,
-			e)
-		pkgLevelIssues = append(pkgLevelIssues, issue)
-	}
-	slices.Sort(pkgLevelIssues)
-	for _, pkgLevelIssue := range pkgLevelIssues {
-		sb.WriteString(pkgLevelIssue + "\n")
+		// Sort to make the slice deterministic (which is necessary for testing)
+		slices.Sort(topLevelIssues)
+		sbWithDash := util.StringBuilderWithPrefixAndSuffix(&initialStringBuilder, "\t- ", "\n")
+		for _, topLevelIssue := range topLevelIssues {
+			sbWithDash.Writef(topLevelIssue)
+		}
 	}
 
-	return sb.String()
+	// Enumerate the failed package-level checks.
+	if len(checker.ErrsAndPacks) > 0 {
+		initialStringBuilder.WriteString("\n")
+		sbWithTab.Writef("Conformance issues in packages:")
+		pkgLevelIssues := make([]string, 0)
+		for e, p := range checker.ErrsAndPacks {
+			var packageString string
+			if len(p) == 1 {
+				packageString = "package"
+			} else {
+				packageString = "packages"
+			}
+			issue := fmt.Sprintf("%d/%d %s failed: %s",
+				len(p),
+				checker.NumberOfSBOMPackages(),
+				packageString,
+				e)
+			pkgLevelIssues = append(pkgLevelIssues, issue)
+		}
+		slices.Sort(pkgLevelIssues)
+		sbWithDash := util.StringBuilderWithPrefixAndSuffix(&initialStringBuilder, "\t- ", "\n")
+		for _, pkgLevelIssue := range pkgLevelIssues {
+			sbWithDash.Writef(pkgLevelIssue)
+		}
+	}
+	return initialStringBuilder.String()
 }
 
 // Checks all specs.

--- a/pkg/checkers/base/base_test.go
+++ b/pkg/checkers/base/base_test.go
@@ -1108,26 +1108,7 @@ func TestEOChecker(t *testing.T) {
 
 	// Run checks
 	checker.RunChecks()
-
-	expectedTextSummary := `Analyzed SBOM package with 4 packages. 4 of these packages failed the conformance checks.
-
-Top-level conformance issues:
-Creator organization is Some Other Company, but should always be 'Google LLC'.. [EO]
-
-Conformance issues in packages:
-1/4 package failed: has no PackageName field
-3/4 packages failed: The supplier field is missing
-4/4 packages failed: has no PackageExternalReferences field
-`
-
 	results := checker.Results()
-	if !strings.EqualFold(expectedTextSummary, results.TextSummary) {
-		t.Errorf(
-			"The text summary was not as expected. \nWas:\n'%s'\nExpected:\n'%s'\n",
-			results.TextSummary,
-			expectedTextSummary,
-		)
-	}
 
 	if results.Summary.TotalSBOMPackages != 4 {
 		t.Errorf("There should be 4 TotalSBOMPackages but the results only had %d\n",
@@ -1318,27 +1299,7 @@ func TestGoogleChecker(t *testing.T) {
 
 	// Run checks
 	checker.RunChecks()
-
-	expectedTextSummary := `Analyzed SBOM package with 4 packages. 3 of these packages failed the conformance checks.
-
-Top-level conformance issues:
-Creator organization is Some Other Company, but should always be 'Google LLC'.. [Google]
-SBOM has no License Identifier field. [Google]
-
-Conformance issues in packages:
-1/4 package failed: has neither Concluded License nor License From Files. Both of these cannot be absent from a package.
-1/4 package failed: has no PackageName field
-3/4 packages failed: has no PackageSupplier field
-`
-
 	results := checker.Results()
-	if !strings.EqualFold(expectedTextSummary, results.TextSummary) {
-		t.Errorf(
-			"The text summary was not as expected. \nWas:\n'%s'\nExpected:\n'%s'\n",
-			results.TextSummary,
-			expectedTextSummary,
-		)
-	}
 
 	if results.Summary.TotalSBOMPackages != 4 {
 		t.Errorf("There should be 4 TotalSBOMPackages but the results only had %d\n",
@@ -1501,25 +1462,7 @@ func TestSPDXChecker(t *testing.T) {
 
 	// Run checks
 	checker.RunChecks()
-
-	expectedTextSummary := `Analyzed SBOM package with 4 packages. 3 of these packages failed the conformance checks.
-
-Top-level conformance issues:
-Creator organization is Some Other Company, but should always be 'Google LLC'.. [SPDX]
-
-Conformance issues in packages:
-1/4 package failed: has no PackageName field
-3/4 packages failed: has no PackageDownloadLocation field
-`
-
 	results := checker.Results()
-	if !strings.EqualFold(expectedTextSummary, results.TextSummary) {
-		t.Errorf(
-			"The text summary was not as expected. \nWas:\n'%s'\nExpected:\n'%s'\n",
-			results.TextSummary,
-			expectedTextSummary,
-		)
-	}
 
 	if results.Summary.TotalSBOMPackages != 4 {
 		t.Errorf("There should be 4 TotalSBOMPackages but the results only had %d\n",

--- a/pkg/checkers/base/base_test.go
+++ b/pkg/checkers/base/base_test.go
@@ -298,7 +298,7 @@ func TestPkgResultsForMultiplePackagesAndErrorsAndSpecs(t *testing.T) {
 					{
 						Error: &types.FieldError{
 							ErrorType: "missingField",
-							ErrorMsg:  "has no PackageVersion field",
+							ErrorMsg:  "Has no PackageVersion field",
 						},
 						CheckName:      "Check that SBOM packages have a valid version",
 						ReportedBySpec: []string{"EO"},
@@ -329,7 +329,7 @@ func TestPkgResultsForMultiplePackagesAndErrorsAndSpecs(t *testing.T) {
 				Errors: []*types.NonConformantField{{
 					Error: &types.FieldError{
 						ErrorType: "missingField",
-						ErrorMsg:  "has no PackageName field",
+						ErrorMsg:  "Has no PackageName field",
 					},
 					CheckName:      "Check that SBOM packages have a name",
 					ReportedBySpec: []string{"EO", "SPDX"},
@@ -894,7 +894,7 @@ func TestEOPkgResults(t *testing.T) {
 				Errors: []*types.NonConformantField{{
 					Error: &types.FieldError{
 						ErrorType: "missingField",
-						ErrorMsg:  "has no PackageVersion field",
+						ErrorMsg:  "Has no PackageVersion field",
 					},
 					CheckName:      "Check that SBOM packages have a valid version",
 					ReportedBySpec: []string{"EO"},
@@ -923,7 +923,7 @@ func TestEOPkgResults(t *testing.T) {
 				Errors: []*types.NonConformantField{{
 					Error: &types.FieldError{
 						ErrorType: "missingField",
-						ErrorMsg:  "has no PackageVersion field",
+						ErrorMsg:  "Has no PackageVersion field",
 					},
 					CheckName:      "Check that SBOM packages have a valid version",
 					ReportedBySpec: []string{"EO"},
@@ -952,7 +952,7 @@ func TestEOPkgResults(t *testing.T) {
 				Errors: []*types.NonConformantField{{
 					Error: &types.FieldError{
 						ErrorType: "missingField",
-						ErrorMsg:  "has no PackageVersion field",
+						ErrorMsg:  "Has no PackageVersion field",
 					},
 					CheckName:      "Check that SBOM packages have a valid version",
 					ReportedBySpec: []string{"EO"},
@@ -980,7 +980,7 @@ func TestEOPkgResults(t *testing.T) {
 				Errors: []*types.NonConformantField{{
 					Error: &types.FieldError{
 						ErrorType: "missingField",
-						ErrorMsg:  "has no PackageName field",
+						ErrorMsg:  "Has no PackageName field",
 					},
 					CheckName:      "Check that SBOM packages have a name",
 					ReportedBySpec: []string{"EO"},
@@ -1009,7 +1009,7 @@ func TestEOPkgResults(t *testing.T) {
 				Errors: []*types.NonConformantField{{
 					Error: &types.FieldError{
 						ErrorType: "missingField",
-						ErrorMsg:  "has no PackageName field",
+						ErrorMsg:  "Has no PackageName field",
 					},
 					CheckName:      "Check that SBOM packages have a name",
 					ReportedBySpec: []string{"EO"},
@@ -1033,7 +1033,7 @@ func TestEOPkgResults(t *testing.T) {
 				Errors: []*types.NonConformantField{{
 					Error: &types.FieldError{
 						ErrorType: "missingField",
-						ErrorMsg:  "has no PackageExternalReferences field",
+						ErrorMsg:  "Has no PackageExternalReferences field",
 					},
 					CheckName:      "Check that SBOM packages have external references",
 					ReportedBySpec: []string{"EO"},
@@ -1058,7 +1058,7 @@ func TestEOPkgResults(t *testing.T) {
 				Errors: []*types.NonConformantField{{
 					Error: &types.FieldError{
 						ErrorType: "missingField",
-						ErrorMsg:  "has no PackageExternalReferences field",
+						ErrorMsg:  "Has no PackageExternalReferences field",
 					},
 					CheckName:      "Check that SBOM packages have external references",
 					ReportedBySpec: []string{"EO"},
@@ -1157,8 +1157,8 @@ func TestEOChecker(t *testing.T) {
 	if results.PkgResults[0].Errors[1].Error.ErrorType != "missingField" {
 		t.Errorf("Should be missingField ErrorType")
 	}
-	if results.PkgResults[0].Errors[1].Error.ErrorMsg != "has no PackageExternalReferences field" {
-		t.Errorf("Should be 'has no PackageExternalReferences field' ErrorMsg")
+	if results.PkgResults[0].Errors[1].Error.ErrorMsg != "Has no PackageExternalReferences field" {
+		t.Errorf("Should be 'Has no PackageExternalReferences field' ErrorMsg")
 	}
 	if !slices.Equal(results.PkgResults[0].Errors[1].ReportedBySpec, []string{"EO"}) {
 		t.Errorf("The issue should be reported by EO")
@@ -1175,8 +1175,8 @@ func TestEOChecker(t *testing.T) {
 	if results.PkgResults[1].Errors[0].Error.ErrorType != "missingField" {
 		t.Errorf("Should be missingField ErrorType")
 	}
-	if results.PkgResults[1].Errors[0].Error.ErrorMsg != "has no PackageName field" {
-		t.Errorf("Should be 'has no PackageName field' ErrorMsg")
+	if results.PkgResults[1].Errors[0].Error.ErrorMsg != "Has no PackageName field" {
+		t.Errorf("Should be 'Has no PackageName field' ErrorMsg")
 	}
 	if !slices.Equal(results.PkgResults[1].Errors[0].ReportedBySpec, []string{"EO"}) {
 		t.Errorf("The issue should be reported by EO")
@@ -1193,8 +1193,8 @@ func TestEOChecker(t *testing.T) {
 	if results.PkgResults[1].Errors[2].Error.ErrorType != "missingField" {
 		t.Errorf("Should be missingField ErrorType")
 	}
-	if results.PkgResults[1].Errors[2].Error.ErrorMsg != "has no PackageExternalReferences field" {
-		t.Errorf("Should be 'has no PackageExternalReferences field' ErrorMsg")
+	if results.PkgResults[1].Errors[2].Error.ErrorMsg != "Has no PackageExternalReferences field" {
+		t.Errorf("Should be 'Has no PackageExternalReferences field' ErrorMsg")
 	}
 	if !slices.Equal(results.PkgResults[1].Errors[2].ReportedBySpec, []string{"EO"}) {
 		t.Errorf("The issue should be reported by EO")
@@ -1223,8 +1223,8 @@ func TestEOChecker(t *testing.T) {
 	if results.PkgResults[2].Errors[1].Error.ErrorType != "missingField" {
 		t.Errorf("Should be missingField ErrorType")
 	}
-	if results.PkgResults[2].Errors[1].Error.ErrorMsg != "has no PackageExternalReferences field" {
-		t.Errorf("Should be 'has no PackageExternalReferences field' ErrorMsg")
+	if results.PkgResults[2].Errors[1].Error.ErrorMsg != "Has no PackageExternalReferences field" {
+		t.Errorf("Should be 'Has no PackageExternalReferences field' ErrorMsg")
 	}
 	if !slices.Equal(results.PkgResults[2].Errors[1].ReportedBySpec, []string{"EO"}) {
 		t.Errorf("The issue should be reported by EO")
@@ -1244,8 +1244,8 @@ func TestEOChecker(t *testing.T) {
 	if results.PkgResults[3].Errors[0].Error.ErrorType != "missingField" {
 		t.Errorf("Should be missingField ErrorType")
 	}
-	if results.PkgResults[3].Errors[0].Error.ErrorMsg != "has no PackageExternalReferences field" {
-		t.Errorf("Should be 'has no PackageExternalReferences field' ErrorMsg")
+	if results.PkgResults[3].Errors[0].Error.ErrorMsg != "Has no PackageExternalReferences field" {
+		t.Errorf("Should be 'Has no PackageExternalReferences field' ErrorMsg")
 	}
 	if !slices.Equal(results.PkgResults[2].Errors[0].ReportedBySpec, []string{"EO"}) {
 		t.Errorf("The issue should be reported by EO")
@@ -1264,15 +1264,15 @@ func TestEOChecker(t *testing.T) {
 		"another package",
 		"last package",
 	}
-	if !slices.Equal(results.ErrsAndPacks["has no PackageExternalReferences field"], expect) {
+	if !slices.Equal(results.ErrsAndPacks["Has no PackageExternalReferences field"], expect) {
 		t.Errorf(
 			"Expected %+v but got %+v",
 			expect,
-			results.ErrsAndPacks["has no PackageExternalReferences field"],
+			results.ErrsAndPacks["Has no PackageExternalReferences field"],
 		)
 	}
 	/*expect = []string{"Package-1"}
-	if !slices.Equal(results.ErrsAndPacks["has no PackageName field"], expect) {
+	if !slices.Equal(results.ErrsAndPacks["Has no PackageName field"], expect) {
 		t.Error("Wrong")
 	}*/
 }
@@ -1337,8 +1337,8 @@ func TestGoogleChecker(t *testing.T) {
 	if results.PkgResults[0].Errors[0].Error.ErrorType != "missingField" {
 		t.Errorf("Should be missingField ErrorType")
 	}
-	if results.PkgResults[0].Errors[0].Error.ErrorMsg != "has no PackageSupplier field" {
-		t.Errorf("Should be 'has no PackageSupplier field' ErrorMsg")
+	if results.PkgResults[0].Errors[0].Error.ErrorMsg != "Has no PackageSupplier field" {
+		t.Errorf("Should be 'Has no PackageSupplier field' ErrorMsg")
 	}
 	if results.PkgResults[0].Errors[1].Error.ErrorType != "missingField" {
 		t.Errorf("Should be missingField ErrorType")
@@ -1366,14 +1366,14 @@ func TestGoogleChecker(t *testing.T) {
 	if results.PkgResults[1].Errors[0].Error.ErrorType != "missingField" {
 		t.Errorf("Should be missingField ErrorType")
 	}
-	if results.PkgResults[1].Errors[0].Error.ErrorMsg != "has no PackageName field" {
-		t.Errorf("Should be 'has no PackageName field' ErrorMsg")
+	if results.PkgResults[1].Errors[0].Error.ErrorMsg != "Has no PackageName field" {
+		t.Errorf("Should be 'Has no PackageName field' ErrorMsg")
 	}
 	if results.PkgResults[1].Errors[1].Error.ErrorType != "missingField" {
 		t.Errorf("Should be missingField ErrorType")
 	}
-	if results.PkgResults[1].Errors[1].Error.ErrorMsg != "has no PackageSupplier field" {
-		t.Errorf("Should be 'has no PackageSupplier field' ErrorMsg")
+	if results.PkgResults[1].Errors[1].Error.ErrorMsg != "Has no PackageSupplier field" {
+		t.Errorf("Should be 'Has no PackageSupplier field' ErrorMsg")
 	}
 	if !slices.Equal(results.PkgResults[1].Errors[0].ReportedBySpec, []string{"Google"}) {
 		t.Errorf("The issue should be reported by Google")
@@ -1396,8 +1396,8 @@ func TestGoogleChecker(t *testing.T) {
 	if results.PkgResults[2].Errors[0].Error.ErrorType != "missingField" {
 		t.Errorf("Should be missingField ErrorType")
 	}
-	if results.PkgResults[2].Errors[0].Error.ErrorMsg != "has no PackageSupplier field" {
-		t.Errorf("Should be 'has no PackageSupplier field' ErrorMsg")
+	if results.PkgResults[2].Errors[0].Error.ErrorMsg != "Has no PackageSupplier field" {
+		t.Errorf("Should be 'Has no PackageSupplier field' ErrorMsg")
 	}
 	if !slices.Equal(results.PkgResults[2].Errors[0].ReportedBySpec, []string{"Google"}) {
 		t.Errorf("The issue should be reported by Google")
@@ -1427,7 +1427,7 @@ func TestGoogleChecker(t *testing.T) {
 		"Package-1",
 		"another package",
 	}
-	if !slices.Equal(results.ErrsAndPacks["has no PackageSupplier field"], expect) {
+	if !slices.Equal(results.ErrsAndPacks["Has no PackageSupplier field"], expect) {
 		t.Error("Wrong")
 	}
 	/*expect = []string{"Package"}
@@ -1435,7 +1435,7 @@ func TestGoogleChecker(t *testing.T) {
 		t.Error("Wrong")
 	}
 	expect = []string{"Package-1"}
-	if !slices.Equal(results.ErrsAndPacks["has no PackageName field"], expect) {
+	if !slices.Equal(results.ErrsAndPacks["Has no PackageName field"], expect) {
 		t.Error("Wrong")
 	}*/
 }
@@ -1515,18 +1515,18 @@ func TestSPDXChecker(t *testing.T) {
 	if results.PkgResults[1].Errors[0].Error.ErrorType != "missingField" {
 		t.Errorf("Should be missingField ErrorType")
 	}
-	if results.PkgResults[1].Errors[0].Error.ErrorMsg != "has no PackageName field" {
+	if results.PkgResults[1].Errors[0].Error.ErrorMsg != "Has no PackageName field" {
 		t.Errorf(
-			"Should be 'has no PackageName field' ErrorMsg but was %s\n",
+			"Should be 'Has no PackageName field' ErrorMsg but was %s\n",
 			results.PkgResults[1].Errors[0].Error.ErrorMsg,
 		)
 	}
 	if results.PkgResults[1].Errors[1].Error.ErrorType != "missingField" {
 		t.Errorf("Should be missingField ErrorType")
 	}
-	if results.PkgResults[1].Errors[1].Error.ErrorMsg != "has no PackageDownloadLocation field" {
+	if results.PkgResults[1].Errors[1].Error.ErrorMsg != "Has no PackageDownloadLocation field" {
 		t.Errorf(
-			"Should be 'has no PackageDownloadLocation field' ErrorMsg but was %s\n",
+			"Should be 'Has no PackageDownloadLocation field' ErrorMsg but was %s\n",
 			results.PkgResults[1].Errors[1].Error.ErrorMsg,
 		)
 	}
@@ -1554,9 +1554,9 @@ func TestSPDXChecker(t *testing.T) {
 	if results.PkgResults[2].Errors[0].Error.ErrorType != "missingField" {
 		t.Errorf("Should be missingField ErrorType")
 	}
-	if results.PkgResults[2].Errors[0].Error.ErrorMsg != "has no PackageDownloadLocation field" {
+	if results.PkgResults[2].Errors[0].Error.ErrorMsg != "Has no PackageDownloadLocation field" {
 		t.Errorf(
-			"Should be 'has no PackageDownloadLocation field' ErrorMsg but was %s\n",
+			"Should be 'Has no PackageDownloadLocation field' ErrorMsg but was %s\n",
 			results.PkgResults[2].Errors[0].Error.ErrorMsg,
 		)
 	}
@@ -1581,9 +1581,9 @@ func TestSPDXChecker(t *testing.T) {
 	if results.PkgResults[3].Errors[0].Error.ErrorType != "missingField" {
 		t.Errorf("Should be missingField ErrorType")
 	}
-	if results.PkgResults[3].Errors[0].Error.ErrorMsg != "has no PackageDownloadLocation field" {
+	if results.PkgResults[3].Errors[0].Error.ErrorMsg != "Has no PackageDownloadLocation field" {
 		t.Errorf(
-			"Should be 'has no PackageDownloadLocation field' ErrorMsg but was %s\n",
+			"Should be 'Has no PackageDownloadLocation field' ErrorMsg but was %s\n",
 			results.PkgResults[3].Errors[0].Error.ErrorMsg,
 		)
 	}

--- a/pkg/checkers/common/common.go
+++ b/pkg/checkers/common/common.go
@@ -120,7 +120,7 @@ func wrongDateFormat(
 func wrongCreatorName(
 	creator, spec string,
 ) *types.NonConformantField {
-	e := fmt.Sprintf("Creator organization is %s, "+
+	e := fmt.Sprintf("Creator organization is '%s', "+
 		"but should always be 'Google LLC'.",
 		creator)
 	return &types.NonConformantField{

--- a/pkg/checkers/types/types.go
+++ b/pkg/checkers/types/types.go
@@ -124,7 +124,7 @@ func CreateWronglyFormattedFieldError(
 func MandatoryPackageFieldError(
 	field, spec string,
 ) *NonConformantField {
-	e := fmt.Sprintf("has no %s field", field)
+	e := fmt.Sprintf("Has no %s field", field)
 	issue := &NonConformantField{
 		Error: &FieldError{
 			ErrorType: "missingField",

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 
@@ -139,4 +140,31 @@ func RunPkgLevelChecks(
 		pkgResults = append(pkgResults, pkgResult)
 	}
 	return pkgResults
+}
+
+// StringBuilder augments strings.Builder to allow for easier formatting and
+// application of prefixes and suffixes.
+type StringBuilder struct {
+	s      *strings.Builder
+	prefix string
+	suffix string
+}
+
+// StringBuilderWithPrefix returns a StringBuilder that will send all writes to
+// initialStringBuilder, with the prefix and suffix applied before and after
+// each write.
+func StringBuilderWithPrefixAndSuffix(
+	initialStringBuilder *strings.Builder,
+	prefix string,
+	suffix string,
+) *StringBuilder {
+	return &StringBuilder{s: initialStringBuilder, prefix: prefix, suffix: suffix}
+}
+
+// Writef formats according to a format specifier and writes to the StringBuilder,
+// applying the prefix and suffix.
+func (sb *StringBuilder) Writef(format string, a ...any) {
+	sb.s.WriteString(sb.prefix)
+	fmt.Fprintf(sb.s, format, a...)
+	sb.s.WriteString(sb.suffix)
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	types "github.com/google/sbom-conformance/pkg/checkers/types"
 )
 
@@ -52,5 +53,24 @@ func TestDeduplicateIssues(t *testing.T) {
 	}
 	if !strings.EqualFold(deduplicated[0].ErrorType, "formatError") {
 		t.Error("Should be a 'formatError'")
+	}
+}
+
+func TestStringBuilder(t *testing.T) {
+	initialStringBuilder := strings.Builder{}
+
+	// test that initial contents carry through
+	initialStringBuilder.WriteString("a ")
+
+	// test that the prefix and the suffix are applied
+	sb := StringBuilderWithPrefixAndSuffix(&initialStringBuilder, "pre ", " post")
+	sb.Writef("%s %s", "Hello", "World")
+
+	// test the writes to initialStringBuilder carry through
+	initialStringBuilder.WriteString(" b")
+
+	expected := "a pre Hello World post b"
+	if diff := cmp.Diff(expected, initialStringBuilder.String()); diff != "" {
+		t.Errorf("Encountered checker.Results() diff (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
This PR improves the text summary created by the library.

Running `go run ./internal/example -specs=eo,spdx -output text  -focus=error` now outputs

```
Summary:
	Analyzed an SBOM with 4 package(s). 1 top-level conformance check(s) failed. 4 package(s) had at least one failing conformance check.

	Top-level conformance issues:
	- Creator organization is 'Some Other Company', but should always be 'Google LLC'.. [EO SPDX]

	Conformance issues in packages:
	- Has no PackageDownloadLocation field: 3/4 packages failed.
	- Has no PackageExternalReferences field: 4/4 packages failed.
	- Has no PackageName field: 1/4 packages failed.
	- The supplier field is missing: 3/4 packages failed.

The supplier field is missing --- affects 3/4 packages
Has no PackageExternalReferences field --- affects 4/4 packages
Has no PackageName field --- affects 1/4 package
Has no PackageDownloadLocation field --- affects 3/4 packages

Top-level issues:
Issue:
   Creator organization is 'Some Other Company', but should always be 'Google LLC'.
   NonConformant With Specs:  [EO SPDX]
```

while previously, that command output

```
Results
Analyzed SBOM package with 4 packages. 4 of these packages failed the conformance checks.

Top-level conformance issues:
Creator organization is Some Other Company, but should always be 'Google LLC'.. [EO SPDX]

Conformance issues in packages:
1/4 package failed: has no PackageName field
3/4 packages failed: The supplier field is missing
3/4 packages failed: has no PackageDownloadLocation field
4/4 packages failed: has no PackageExternalReferences field

has no PackageName field --- affects 1/4 package
has no PackageDownloadLocation field --- affects 3/4 packages
The supplier field is missing --- affects 3/4 packages
has no PackageExternalReferences field --- affects 4/4 packages

Top-level issues:
Issue:
   Creator organization is Some Other Company, but should always be 'Google LLC'.
   NonConformant With Specs:  [EO SPDX]
```

