### PR TITLE
Document, fix, and test the NTIA timestamp check

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ A PDF of the specification can be found in https://www.ntia.doc.gov/files/ntia/p
 
 This refers to the "Author of SBOM Data" data field in the NTIA specification. It is a top-level check that passes if the [Creator](https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#68-creator-field) field contains at least one entry.
 
+#### Timestamp
+
+This refers to the "Timestamp" data field in the NTIA specification. It is a top-level check that passes if the [Created](https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#69-created-field) field is present and non-empty.
+
 #### Name
 
 This refers to the "Component Name" data field in the NTIA specification. It is a package-level check that passes if the [Name](https://spdx.github.io/spdx-spec/v2.3/package-information/#71-package-name-field) field is present and non-empty.

--- a/pkg/checkers/base/base_test.go
+++ b/pkg/checkers/base/base_test.go
@@ -421,7 +421,7 @@ func TestEOTopLevelChecks(t *testing.T) {
 		expected []*types.TopLevelCheckResult
 	}{
 		{
-			name: "Missing field causes author check to fail",
+			name: "Missing fields cause author and timestamp checks to fail",
 			sbom: `{
 				"spdxVersion": "SPDX-2.3",
 				"name": "SimpleSBOM",
@@ -442,7 +442,7 @@ func TestEOTopLevelChecks(t *testing.T) {
 					Specs:  []string{"EO"},
 				},
 				{
-					Name:   "Check that the SBOMs creator is formatted correctly",
+					Name:   "Check that the SBOM has a timestamp",
 					Passed: false,
 					Specs:  []string{"EO"},
 				},
@@ -454,46 +454,50 @@ func TestEOTopLevelChecks(t *testing.T) {
 			},
 		},
 		{
-			name: "Empty field causes author check to fail",
-			sbom: `{
-				"spdxVersion": "SPDX-2.3",
-				"name": "SimpleSBOM",
-				"creationInfo": {"creators": []},
-				"packages": [{
-					"name": "Foo",
-					"SPDXID": "SPDXRef-foo"
-				}]
-			}`,
-			expected: []*types.TopLevelCheckResult{
-				{
-					Name:   "Check that the SBOM has an SPDX version",
-					Passed: true,
-					Specs:  []string{"EO"},
-				},
-				{
-					Name:   "Check that the SBOM has at least one creator",
-					Passed: false,
-					Specs:  []string{"EO"},
-				},
-				{
-					Name:   "Check that the SBOMs creator is formatted correctly",
-					Passed: false,
-					Specs:  []string{"EO"},
-				},
-				{
-					Name:   "Check that the SBOMs packages are correctly formatted",
-					Passed: true,
-					Specs:  []string{"EO"},
-				},
-			},
-		},
-		{
-			name: "Author check passes",
+			name: "Empty fields cause author and timestamp checks to fail",
 			sbom: `{
 				"spdxVersion": "SPDX-2.3",
 				"name": "SimpleSBOM",
 				"creationInfo": {
-					"creators": ["Organization: Foo"]
+					"creators": [],
+					"created": ""
+				},
+				"packages": [{
+					"name": "Foo",
+					"SPDXID": "SPDXRef-foo"
+				}]
+			}`,
+			expected: []*types.TopLevelCheckResult{
+				{
+					Name:   "Check that the SBOM has an SPDX version",
+					Passed: true,
+					Specs:  []string{"EO"},
+				},
+				{
+					Name:   "Check that the SBOM has at least one creator",
+					Passed: false,
+					Specs:  []string{"EO"},
+				},
+				{
+					Name:   "Check that the SBOM has a timestamp",
+					Passed: false,
+					Specs:  []string{"EO"},
+				},
+				{
+					Name:   "Check that the SBOMs packages are correctly formatted",
+					Passed: true,
+					Specs:  []string{"EO"},
+				},
+			},
+		},
+		{
+			name: "Author and timestamp checks pass",
+			sbom: `{
+				"spdxVersion": "SPDX-2.3",
+				"name": "SimpleSBOM",
+				"creationInfo": {
+					"creators": ["Organization: Foo"],
+					"created": "some timestamp"
 				},
 				"packages": [{
 					"name": "Foo",
@@ -512,8 +516,8 @@ func TestEOTopLevelChecks(t *testing.T) {
 					Specs:  []string{"EO"},
 				},
 				{
-					Name:   "Check that the SBOMs creator is formatted correctly",
-					Passed: false,
+					Name:   "Check that the SBOM has a timestamp",
+					Passed: true,
 					Specs:  []string{"EO"},
 				},
 				{
@@ -1126,8 +1130,8 @@ func TestEOChecker(t *testing.T) {
 		t.Errorf("The 'EO' spec summary should be Conformant=true but was Conformant=%t\n",
 			results.Summary.SpecSummaries["EO"].Conformant)
 	}
-	if results.Summary.SpecSummaries["EO"].PassedChecks != 4 {
-		t.Errorf("The 'EO' spec summary should be PassedChecks=4 but was PassedChecks=%d\n",
+	if results.Summary.SpecSummaries["EO"].PassedChecks != 5 {
+		t.Errorf("The 'EO' spec summary should be PassedChecks=5 but was PassedChecks=%d\n",
 			results.Summary.SpecSummaries["EO"].PassedChecks)
 	}
 	if len(results.PkgResults) != results.Summary.FailedSBOMPackages {

--- a/pkg/checkers/eo/checks.go
+++ b/pkg/checkers/eo/checks.go
@@ -36,6 +36,13 @@ func checkRelationshipsFields(
 	return issues
 }
 
+func MustHaveTimestamp(sbom *v23.Document, spec string) []*types.NonConformantField {
+	if sbom.CreationInfo == nil || sbom.CreationInfo.Created == "" {
+		return []*types.NonConformantField{types.MandatoryPackageFieldError("Created", spec)}
+	}
+	return nil
+}
+
 func MustHaveSupplier(
 	sbomPack *v23.Package,
 	spec, checkName string,

--- a/pkg/checkers/eo/eo.go
+++ b/pkg/checkers/eo/eo.go
@@ -42,8 +42,8 @@ func (eoChecker *EOChecker) InitChecks() {
 			Impl: common.SBOMHasAtLeastOneCreator,
 		},
 		{
-			Name: "Check that the SBOMs creator is formatted correctly",
-			Impl: common.SBOMHasCorrectCreationInfo,
+			Name: "Check that the SBOM has a timestamp",
+			Impl: MustHaveTimestamp,
 		},
 		{
 			Name: "Check that the SBOMs packages are correctly formatted",


### PR DESCRIPTION
There isn't currently a check for the timestamp requirement. This PR replaces a check that mixes a few things with a simple check for the timestamp.