### PR TITLE
Simplify CLI options

### DIFF
--- a/internal/example/main.go
+++ b/internal/example/main.go
@@ -56,11 +56,6 @@ var (
 		"View summary of a particular spec. Same options as 'specs' flag",
 	)
 	flagTextSummary   = flag.Bool("text-summary", true, "Set to true to get a textual summary")
-	flagGetAllResults = flag.Bool(
-		"get-all-results",
-		false,
-		"Enable to get all results in JSON format",
-	)
 	flagGetChecks    = flag.Bool("get-checks", false, "Prints the checks in the analysis if true")
 	validFocus       = []string{"package", "error"}
 	validOutput      = []string{"text", "json"}
@@ -173,15 +168,6 @@ func main() {
 
 	if *flagTextSummary {
 		fmt.Println(checker.Results().TextSummary)
-	}
-
-	if *flagGetAllResults {
-		b, err := json.MarshalIndent(checker.Results(), "", "  ")
-		if err != nil {
-			panic(err)
-		}
-		fmt.Println(string(b))
-		return
 	}
 
 	if *flagGetChecks {

--- a/internal/example/main.go
+++ b/internal/example/main.go
@@ -50,12 +50,7 @@ var (
 		"text",
 		"The output format. Options are 'text' or 'json'.",
 	)
-	flagSpecSummary = flag.String(
-		"spec-summary",
-		"",
-		"View summary of a particular spec. Same options as 'specs' flag",
-	)
-	flagTextSummary   = flag.Bool("text-summary", true, "Set to true to get a textual summary")
+	flagTextSummary  = flag.Bool("text-summary", true, "Set to true to get a textual summary")
 	flagGetChecks    = flag.Bool("get-checks", false, "Prints the checks in the analysis if true")
 	validFocus       = []string{"package", "error"}
 	validOutput      = []string{"text", "json"}
@@ -101,23 +96,6 @@ func main() {
 	if len(cleanedSpecs) == 0 {
 		fmt.Println("We need at least one spec")
 		return
-	}
-
-	// Get the SpecSummary flags
-	// We validate the specs
-	var specsForSummary []string
-	if *flagSpecSummary != "" {
-		specsForSummary = strings.Split(*flagSpecSummary, ",")
-		specsForSummary := removeDuplicates(specsForSummary)
-		for _, specForSummary := range specsForSummary {
-			if !slices.Contains(validSpecs, specForSummary) {
-				fmt.Println(specForSummary, "is not a valid spec")
-				return
-			}
-			if strings.ToLower(specForSummary) == "all" && len(specsForSummary) != 1 {
-				fmt.Println("If you set --spec-summary to 'all', don't specify other specs")
-			}
-		}
 	}
 
 	if *flagFocus != "package" && *flagFocus != "error" {
@@ -207,46 +185,6 @@ func main() {
 			getChecks.WriteString(checkLine.String())
 		}
 		fmt.Println(getChecks.String())
-	}
-
-	// Print spec stats
-	if len(specsForSummary) != 0 {
-		var specsSummary strings.Builder
-		result := checker.Results()
-		if strings.ToLower(specsForSummary[0]) == "all" {
-			for specName, cir := range result.Summary.SpecSummaries {
-				var conformant string
-				if cir.Conformant {
-					conformant = fmt.Sprintf("Conformant %s", greenCheck)
-				} else {
-					conformant = fmt.Sprintf("NOT conformant %s", redCross)
-				}
-				specsSummary.WriteString(fmt.Sprintf("%s: %d/%d checks passed | %s\n",
-					specName,
-					cir.PassedChecks,
-					cir.TotalChecks,
-					conformant))
-			}
-		} else {
-			for _, chosenSpec := range specsForSummary {
-				for specName, cir := range result.Summary.SpecSummaries {
-					if strings.EqualFold(specName, chosenSpec) {
-						var conformant string
-						if cir.Conformant {
-							conformant = fmt.Sprintf("Conformant %s", greenCheck)
-						} else {
-							conformant = fmt.Sprintf("NOT conformant %s", redCross)
-						}
-						specsSummary.WriteString(fmt.Sprintf("%s: %d/%d checks passed | %s\n",
-							specName,
-							cir.PassedChecks,
-							cir.TotalChecks,
-							conformant))
-					}
-				}
-			}
-		}
-		fmt.Println(specsSummary.String())
 	}
 
 	if *flagFocus == "package" {

--- a/internal/example/main.go
+++ b/internal/example/main.go
@@ -44,8 +44,7 @@ var (
 		false,
 		"List the packages that failed checks",
 	)
-	flagTextSummary  = flag.Bool("text-summary", true, "Set to true to get a textual summary")
-	flagGetChecks    = flag.Bool("get-checks", false, "Prints the checks in the analysis if true")
+	flagGetChecks    = flag.Bool("get-checks", false, "Print the checks in the analysis")
 	validFocus       = []string{"package", "error"}
 	validOutput      = []string{"text", "json"}
 	validSpecs       = []string{"google", "eo", "spdx", "all"}
@@ -122,9 +121,7 @@ func main() {
 	////                          ////
 	//////////////////////////////////
 
-	if *flagTextSummary {
-		fmt.Println(checker.Results().TextSummary)
-	}
+	fmt.Println(checker.Results().TextSummary)
 
 	if *flagGetChecks {
 		writeCheckName := func(checkName string, specs []string, checkLine *strings.Builder) {

--- a/pkg/checkers/base/base.go
+++ b/pkg/checkers/base/base.go
@@ -352,11 +352,24 @@ func (checker *BaseChecker) TextSummary() string {
 	// Summary
 	sbWithTab.Writef(
 		"Analyzed an SBOM with %d package(s). %d top-level conformance check(s)"+
-			" failed. %d package(s) had at least one failing conformance check.",
+			" failed. %d package(s) had at least one failing conformance check.\n",
 		checker.NumberOfSBOMPackages(),
 		len(checker.TopLevelResults),
 		checker.NumberOfSBOMPackages()-checker.NumberOfCompliantPackages(),
 	)
+	for spec, specSummary := range checker.SpecSummaries() {
+		status := "failed"
+		if specSummary.Conformant {
+			status = "passed"
+		}
+		sbWithTab.Writef(
+			"The %s spec %v. %v/%v checks passed.",
+			spec,
+			status,
+			specSummary.PassedChecks,
+			specSummary.TotalChecks,
+		)
+	}
 
 	// Enumerate the failed top-level checks.
 	if len(checker.TopLevelResults) > 0 {


### PR DESCRIPTION
The current CLI options are overlapping and aren't all needed. This PR simplifies them by
- removing the options (the `get-all-results` flag and the `output` flag) to print structured results from the CLI. I don't think the ability to print structured results is needed at this point (the only use case I can think of is to pipe the results into other shell commands).
- always printing the text summary (previously, it was optional). As a result, we can remove the `text-summary` flag.
- swapping the `focus` string flag with the `packages` boolean flag. Previously, `focus` could be used to print all packages or to print all errors. Since the errors are already always printed in the text summary, we simplify the flag to optionally print the packages.
- moving the spec summaries into the text summary. Since they'll always be printed, this allows us to remove the `spec-summary` flag.

### Previous CLI options
```
  -focus string
    	The focus for the output. 'package' display each failing package and the errors it has. 'error' display a list of the found issues and the packages that has that issue. (default "package")
  -get-all-results
    	Enable to get all results in JSON format
  -get-checks
    	Prints the checks in the analysis if true
  -output string
    	The output format. Options are 'text' or 'json'. (default "text")
  -sbom string
    	The path to the SBOM file to check. The SBOM can be in JSON, YAML or Tagvalue format. (default "testdata/sboms/simple.json")
  -spec-summary string
    	View summary of a particular spec. Same options as 'specs' flag
  -specs string
    	The specs to check. Options are: 'google', 'eo', 'spdx', 'all' (default). (default "all")
  -text-summary
    	Set to true to get a textual summary (default true)
```


### New CLI options
```
  -get-checks
    	Print the checks in the analysis
  -packages
    	List the packages that failed checks
  -sbom string
    	The path to the SBOM file to check. The SBOM can be in JSON, YAML or Tagvalue format. (default "testdata/sboms/simple.json")
  -specs string
    	The specs to check. Options are: 'google', 'eo', 'spdx', 'all' (default). (default "all")
```
