### PR TITLE
Fix potential printf bug

### DIFF
--- a/pkg/checkers/base/base.go
+++ b/pkg/checkers/base/base.go
@@ -386,7 +386,7 @@ func (checker *BaseChecker) TextSummary() string {
 		slices.Sort(topLevelIssues)
 		sbWithDash := util.StringBuilderWithPrefixAndSuffix(&initialStringBuilder, "\t- ", "\n")
 		for _, topLevelIssue := range topLevelIssues {
-			sbWithDash.Writef(topLevelIssue)
+			sbWithDash.Writef("%s", topLevelIssue)
 		}
 	}
 
@@ -412,7 +412,7 @@ func (checker *BaseChecker) TextSummary() string {
 		slices.Sort(pkgLevelIssues)
 		sbWithDash := util.StringBuilderWithPrefixAndSuffix(&initialStringBuilder, "\t- ", "\n")
 		for _, pkgLevelIssue := range pkgLevelIssues {
-			sbWithDash.Writef(pkgLevelIssue)
+			sbWithDash.Writef("%s", pkgLevelIssue)
 		}
 	}
 	return initialStringBuilder.String()


### PR DESCRIPTION
If `topLevelIssue` contains a `%` format sequence, then there is a bug. I'm not sure why this isn't caught by `go vet` - https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/printf#hdr-Inferred_printf_wrappers seems to indicate it should.