### PR TITLE
Add method to initialize BaseChecker with SPDX Document

### DIFF
--- a/pkg/checkers/base/base.go
+++ b/pkg/checkers/base/base.go
@@ -78,6 +78,15 @@ func NewChecker(options ...func(*BaseChecker)) (*BaseChecker, error) {
 	return checker, nil
 }
 
+// Initializes the BaseChecker with the input SBOM. After this call, RunChecks()
+// can be called.
+//
+// Note that this method differs in behavior from SetSBOM(sbom io.Reader); it does
+// not return a copy of the receiver.
+func (checker *BaseChecker) SetSPDXDocument(sbom *v23.Document) {
+	checker.Document = sbom
+}
+
 // Returns a new BaseChecker with the old BaseCheckers specs
 // and the new SBOM. If the BaseChecker has already run a check
 // on an SBOM, invoking `SetSBOM` will not include those results.

--- a/pkg/checkers/base/base_test.go
+++ b/pkg/checkers/base/base_test.go
@@ -105,6 +105,29 @@ func TestTextSummaryDoesNotCrashWithPercentSignInTopLevelCheckName(t *testing.T)
 	}
 }
 
+// Most tests in this file use basechecker.SetSBOM(io.reader). This test exercises
+// the basechecker.SetSPDXDocument(v23.Document) initialization.
+func TestSetSpdxDocument(t *testing.T) {
+	baseChecker, err := NewChecker(WithEOChecker())
+	if err != nil {
+		t.Fatalf("NewChecker(WithEOChecker()) returned unexpected error: %v", err)
+	}
+	sbom := v23.Document{
+		SPDXVersion:  "SPDX-2.3",
+		DocumentName: "foo",
+		Packages:     []*v23.Package{{PackageSPDXIdentifier: "foo"}},
+	}
+	baseChecker.SetSPDXDocument(&sbom)
+	baseChecker.RunChecks()
+	// sanity check for success
+	if results := baseChecker.Results(); len(results.ErrsAndPacks) == 0 {
+		t.Errorf(
+			"len(baseChecker.Results().ErrsAndPacks) == 0, which indicates that no checks were run. The text summary is:\n%s",
+			results.TextSummary,
+		)
+	}
+}
+
 func TestDeduplicatePackageResults(t *testing.T) {
 	t.Parallel()
 	licenseName := "Other License"


### PR DESCRIPTION
This increases the usability for clients that already have a parsed SPDX document.