### PR TITLE
Document, rename, fix, and test the SDPX download location check

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ This is a package-level check that passes if the [Name](https://spdx.github.io/s
 
 This is a package-level check that passes if the [Package SPDX Identifier](https://spdx.github.io/spdx-spec/v2.3/package-information/#72-package-spdx-identifier-field) field is present and conforms to `SPDXRef-<idstring>` where `idstring` only contains letters, numbers, `.`, and/or `-`.
 
+#### Download Location
+
+This is a package-level check that passes if the [Package Download Location](https://spdx.github.io/spdx-spec/v2.3/package-information/#77-package-download-location-field) field is present and not empty.
+
 ## Disclaimer
 
 This is not an officially supported Google product. This project is not eligible for the [Google Open Source Software Vulnerability Rewards Program](https://bughunters.google.com/open-source-security).

--- a/pkg/checkers/spdx/checks.go
+++ b/pkg/checkers/spdx/checks.go
@@ -25,7 +25,7 @@ func CheckDownloadLocation(
 	spec, checkName string,
 ) []*types.NonConformantField {
 	issues := make([]*types.NonConformantField, 0)
-	if !util.IsValidString(sbomPack.PackageDownloadLocation) {
+	if sbomPack.PackageDownloadLocation == "" {
 		issue := types.MandatoryPackageFieldError(
 			types.PackageDownloadLocation, spec,
 		)

--- a/pkg/checkers/spdx/spdx.go
+++ b/pkg/checkers/spdx/spdx.go
@@ -82,7 +82,7 @@ func (spdxChecker *SPDXChecker) InitChecks() {
 			Impl: CheckVerificationCode,
 		},
 		{
-			Name: "Check that SBOM packages' download location is correctly formatted",
+			Name: "Check that SBOM packages have a download location",
 			Impl: CheckDownloadLocation,
 		},
 	}


### PR DESCRIPTION
Previously, the check disallowed `NOASSERTION` and `NONE` but these are allowed by SPDX spec.