### PR TITLE
Refactor EO top level checks

### DIFF
--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -1,0 +1,42 @@
+// package testutil provides test helper functions
+package testutil
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/sbom-conformance/pkg/checkers/types"
+)
+
+// FailedTopLevelCheck represents a check that has failed.
+//
+// This is toplevel version of types.Output.PkgResults. Ideally, the package-level
+// and top-level versions of a list of failed checks are made consistent - either
+// in types.Output or not. This struct and associated function are the first step
+// towards that.
+type FailedTopLevelCheck struct {
+	Name  string
+	Specs []string
+}
+
+func lessTopLevelCheck(a, b FailedTopLevelCheck) bool {
+	return a.Name > b.Name
+}
+
+var FailedTopLevelCheckOpts []cmp.Option = []cmp.Option{
+	cmpopts.EquateEmpty(),
+	cmpopts.SortSlices(lessTopLevelCheck),
+}
+
+// ExtractFailedTopLevelChecks returns the failed checks in the input.
+func ExtractFailedTopLevelChecks(topLeveChecks []*types.TopLevelCheckResult) []FailedTopLevelCheck {
+	failedChecks := []FailedTopLevelCheck{}
+	for _, check := range topLeveChecks {
+		if !check.Passed {
+			failedChecks = append(failedChecks, FailedTopLevelCheck{
+				Name:  check.Name,
+				Specs: check.Specs,
+			})
+		}
+	}
+	return failedChecks
+}

--- a/pkg/testutil/testutil_test.go
+++ b/pkg/testutil/testutil_test.go
@@ -1,0 +1,58 @@
+package testutil_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/sbom-conformance/pkg/checkers/types"
+	"github.com/google/sbom-conformance/pkg/testutil"
+)
+
+func TestExtractFailedTopLevelChecks(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []*types.TopLevelCheckResult
+		want  []testutil.FailedTopLevelCheck
+	}{
+		{
+			name: "Two failed checks are in output",
+			input: []*types.TopLevelCheckResult{
+				{Name: "foo", Passed: false, Specs: []string{"spec"}},
+				{Name: "bar", Passed: false, Specs: []string{"spec"}},
+			},
+			want: []testutil.FailedTopLevelCheck{
+				{Name: "foo", Specs: []string{"spec"}},
+				{Name: "bar", Specs: []string{"spec"}},
+			},
+		},
+		{
+			name: "Two passed checks are not in output",
+			input: []*types.TopLevelCheckResult{
+				{Name: "foo", Passed: true, Specs: []string{"spec"}},
+				{Name: "bar", Passed: true, Specs: []string{"spec"}},
+			},
+		},
+		{
+			name: "Passed check not in output but failed check is",
+			input: []*types.TopLevelCheckResult{
+				{Name: "foo", Passed: false, Specs: []string{"spec"}},
+				{Name: "bar", Passed: true, Specs: []string{"spec"}},
+			},
+			want: []testutil.FailedTopLevelCheck{
+				{Name: "foo", Specs: []string{"spec"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := cmp.Diff(
+				tt.want,
+				testutil.ExtractFailedTopLevelChecks(tt.input),
+				testutil.FailedTopLevelCheckOpts...,
+			); diff != "" {
+				t.Errorf("Encountered ExtractFailedTopLevelChecks diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A function is added to extract failed top level checks from all top level checks. It is added to a testutil package, but I anticipate it will be used by non-test code in the future, so I added tests for it.

This improves the top level EO tests (probably should have been earlier) and is also a first step towards making the output API more consistent.