### PR TITLE
Remove the package verification code check from the SPDX spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ This is a package-level check that passes if the [Package SPDX Identifier](https
 
 This is a package-level check that passes if the [Package Download Location](https://spdx.github.io/spdx-spec/v2.3/package-information/#77-package-download-location-field) field is present and not empty.
 
+#### Files Analyzed
+
+This is a package-level check that passes if either of the following are true:
+- the [Package Verification Code](https://spdx.github.io/spdx-spec/v2.3/package-information/#79-package-verification-code-field) field is missing
+- the [Package Verification Code](https://spdx.github.io/spdx-spec/v2.3/package-information/#79-package-verification-code-field) field is present and the [Files Analyzed](https://spdx.github.io/spdx-spec/v2.3/package-information/#78-files-analyzed-field) field is `true`
+
 ## Disclaimer
 
 This is not an officially supported Google product. This project is not eligible for the [Google Open Source Software Vulnerability Rewards Program](https://bughunters.google.com/open-source-security).

--- a/pkg/checkers/spdx/checks.go
+++ b/pkg/checkers/spdx/checks.go
@@ -16,7 +16,6 @@ package spdx
 
 import (
 	types "github.com/google/sbom-conformance/pkg/checkers/types"
-	"github.com/google/sbom-conformance/pkg/util"
 	v23 "github.com/spdx/tools-golang/spdx/v2/v2_3"
 )
 
@@ -35,20 +34,20 @@ func CheckDownloadLocation(
 	return issues
 }
 
-func CheckVerificationCode(
+func CheckFilesAnalyzed(
 	sbomPack *v23.Package,
 	spec, checkName string,
 ) []*types.NonConformantField {
 	issues := make([]*types.NonConformantField, 0)
-	if sbomPack.FilesAnalyzed {
-		if sbomPack.PackageVerificationCode == nil ||
-			!util.IsValidString(sbomPack.PackageVerificationCode.Value) {
-			issue := types.MandatoryPackageFieldError(
-				types.PackageVerificationCode, spec,
-			)
-			issue.CheckName = checkName
-			issues = append(issues, issue)
-		}
+	if sbomPack.PackageVerificationCode != nil && !sbomPack.FilesAnalyzed {
+		issues = append(issues, &types.NonConformantField{
+			Error: &types.FieldError{
+				ErrorType: "wrongValue",
+				ErrorMsg:  "filesAnalyzed must be true",
+			},
+			CheckName:      checkName,
+			ReportedBySpec: []string{spec},
+		})
 	}
 	return issues
 }

--- a/pkg/checkers/spdx/spdx.go
+++ b/pkg/checkers/spdx/spdx.go
@@ -78,8 +78,8 @@ func (spdxChecker *SPDXChecker) InitChecks() {
 			Impl: common.CheckSPDXID,
 		},
 		{
-			Name: "Check that SBOM packages' verification code is correctly formatted",
-			Impl: CheckVerificationCode,
+			Name: "Check that SBOM packages' filesAnalyzed is true if packageVerificationCode is present",
+			Impl: CheckFilesAnalyzed,
 		},
 		{
 			Name: "Check that SBOM packages have a download location",

--- a/pkg/checkers/types/types.go
+++ b/pkg/checkers/types/types.go
@@ -44,6 +44,7 @@ var (
 	PackageDownloadLocation     = "PackageDownloadLocation"
 	PackageVerificationCode     = "PackageVerificationCode"
 	PackageLicenseConcluded     = "PackageLicenseConcluded"
+	PackageFilesAnalyzed        = "PackageFilesAnalyzed"
 	PackageLicenseInfoFromFiles = "PackageLicenseInfoFromFiles"
 	PackageExternalReferences   = "PackageExternalReferences"
 	PackageSupplier             = "PackageSupplier"


### PR DESCRIPTION
There is some contradictory information in the specification. See https://github.com/spdx/spdx-spec/issues/802. We can choose to be more conservative and not make it required.