### PR TITLE
Fix, document, and test the SPDX Data License field

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ This is a top-level check that passes if, for each entry in the [Other Licensing
 - the [License Identifier](https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/#101-license-identifier-field) field is unique among all entries
 - the [Extracted Text Field](https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/#102-extracted-text-field) is present and not empty
 
+#### Data License
+
+This is a top-level check that passes if the [Data License](https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#62-data-license-field) field is `CC0-1.0`.
+
 #### Name
 
 This is a package-level check that passes if the [Name](https://spdx.github.io/spdx-spec/v2.3/package-information/#71-package-name-field) field is present and non-empty.

--- a/pkg/checkers/base/base_test.go
+++ b/pkg/checkers/base/base_test.go
@@ -755,6 +755,45 @@ func TestSPDXTopLevelChecks(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "DataLicense is missing",
+			sbom: `{
+				"spdxVersion": "SPDX-2.3",
+				"name": "SimpleSBOM",
+				"documentNamespace": "namespace",
+				"SPDXID": "SPDXRef-DOCUMENT",
+				"creationInfo": {
+					"creators": [{"Creator": "Google LLC", "CreatorType": "Organization"}],
+					"created": "2025-04-08T01:25:25Z"
+				}
+			}`,
+			expected: []testutil.FailedTopLevelCheck{
+				{
+					Name:  "Check that the data license is correct",
+					Specs: []string{"SPDX"},
+				},
+			},
+		},
+		{
+			name: "DataLicense has wrong value",
+			sbom: `{
+				"spdxVersion": "SPDX-2.3",
+				"dataLicense": "foo",
+				"name": "SimpleSBOM",
+				"documentNamespace": "namespace",
+				"SPDXID": "SPDXRef-DOCUMENT",
+				"creationInfo": {
+					"creators": [{"Creator": "Google LLC", "CreatorType": "Organization"}],
+					"created": "2025-04-08T01:25:25Z"
+				}
+			}`,
+			expected: []testutil.FailedTopLevelCheck{
+				{
+					Name:  "Check that the data license is correct",
+					Specs: []string{"SPDX"},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -2172,8 +2211,8 @@ func TestGoogleChecker(t *testing.T) {
 		t.Errorf("The 'Google' spec summary should be Conformant=true but was Conformant=%t\n",
 			results.Summary.SpecSummaries["Google"].Conformant)
 	}
-	if results.Summary.SpecSummaries["Google"].PassedChecks != 7 {
-		t.Errorf("The 'Google' spec summary should be PassedChecks=7 but was PassedChecks=%d\n",
+	if results.Summary.SpecSummaries["Google"].PassedChecks != 6 {
+		t.Errorf("The 'Google' spec summary should be PassedChecks=6 but was PassedChecks=%d\n",
 			results.Summary.SpecSummaries["Google"].PassedChecks)
 	}
 	if len(results.PkgResults) != 4 {

--- a/pkg/checkers/common/common.go
+++ b/pkg/checkers/common/common.go
@@ -49,9 +49,14 @@ func SBOMHasDataLicense(
 	spec string,
 ) []*types.NonConformantField {
 	issues := make([]*types.NonConformantField, 0)
-	if !util.IsValidString(doc.DataLicense) {
-		issue := types.CreateFieldError(types.DataLicense, spec)
-		issues = append(issues, issue)
+	if doc.DataLicense != "CC0-1.0" {
+		issues = append(issues, &types.NonConformantField{
+			Error: &types.FieldError{
+				ErrorType: "wrongValue",
+				ErrorMsg:  "DataLicense must be CC0-1.0",
+			},
+			ReportedBySpec: []string{spec},
+		})
 	}
 	return issues
 }

--- a/pkg/checkers/spdx/spdx.go
+++ b/pkg/checkers/spdx/spdx.go
@@ -41,7 +41,7 @@ func (spdxChecker *SPDXChecker) InitChecks() {
 		},
 		// TODO: add a uniqueness check for SPDXID
 		{
-			Name: "Check that the SBOM has a data license",
+			Name: "Check that the data license is correct",
 			Impl: common.SBOMHasDataLicense,
 		},
 		{


### PR DESCRIPTION
Previously, it was only checked if the field was not empty.