### PR TITLE
Document, fix, and test the SPDX SPDXID check

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ This is a top-level check that passes if the [Document Name](https://spdx.github
 
 This is a top-level check that passes if the [Document Namespace](https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#65-spdx-document-namespace-field) field is present and is a RFC 3986 URL with a scheme and without `#` characters.
 
+#### Document SPDXID
+
+This is a top-level check that passes if the [Document SPDX Identifier](https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#63-spdx-identifier-field) field is `SPDXRef-DOCUMENT`.
+
 #### SPDX Version
 
 This is a top-level check that passes if the [SPDX Version](https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#61-spdx-version-field) is present and conforms to `SPDX-M.N`.

--- a/pkg/checkers/base/base_test.go
+++ b/pkg/checkers/base/base_test.go
@@ -578,7 +578,7 @@ func TestSPDXTopLevelChecks(t *testing.T) {
 		expected []testutil.FailedTopLevelCheck
 	}{
 		{
-			name: "SPDX version, name, and namespace checks pass",
+			name: "SPDX version, name, namespace, and SPDXID checks pass",
 			sbom: `{
 				"spdxVersion": "SPDX-2.3",
 				"dataLicense": "CC0-1.0",
@@ -592,11 +592,10 @@ func TestSPDXTopLevelChecks(t *testing.T) {
 			}`,
 		},
 		{
-			name: "SPDX name and namespace checks fail because they are missing",
+			name: "SPDX name, namespace, and SPDXID checks fail because they are missing",
 			sbom: `{
 				"spdxVersion": "SPDX-2.3",
 				"dataLicense": "CC0-1.0",
-				"SPDXID": "SPDXRef-DOCUMENT",
 				"creationInfo": {
 					"creators": [{"Creator": "Google LLC", "CreatorType": "Organization"}],
 					"created": "2025-04-08T01:25:25Z"
@@ -611,15 +610,19 @@ func TestSPDXTopLevelChecks(t *testing.T) {
 					Name:  "Check that the SBOM has a valid Document Namespace",
 					Specs: []string{"SPDX"},
 				},
+				{
+					Name:  "Check that the SBOM has the correct SPDXIdentifier",
+					Specs: []string{"SPDX"},
+				},
 			},
 		},
 		{
-			name: "SPDX name and namespace checks fail because they are empty",
+			name: "SPDX name, namespace, and SPDXID checks fail because they are empty",
 			sbom: `{
 				"spdxVersion": "SPDX-2.3",
 				"dataLicense": "CC0-1.0",
-				"SPDXID": "SPDXRef-DOCUMENT",
 				"name": "",
+				"SPDXID": "SPDXRef-",
 				"documentNamespace": "",
 				"creationInfo": {
 					"creators": [{"Creator": "Google LLC", "CreatorType": "Organization"}],
@@ -633,6 +636,10 @@ func TestSPDXTopLevelChecks(t *testing.T) {
 				},
 				{
 					Name:  "Check that the SBOM has a valid Document Namespace",
+					Specs: []string{"SPDX"},
+				},
+				{
+					Name:  "Check that the SBOM has the correct SPDXIdentifier",
 					Specs: []string{"SPDX"},
 				},
 			},
@@ -694,6 +701,26 @@ func TestSPDXTopLevelChecks(t *testing.T) {
 			expected: []testutil.FailedTopLevelCheck{
 				{
 					Name:  "Check that the SBOM has a valid Document Namespace",
+					Specs: []string{"SPDX"},
+				},
+			},
+		},
+		{
+			name: "SPDX SPDXID check fails because it is not SPDXRef-DOCUMENT",
+			sbom: `{
+				"spdxVersion": "SPDX-2.3",
+				"dataLicense": "CC0-1.0",
+				"name": "foo",
+				"SPDXID": "SPDXRef-foo",
+				"documentNamespace": "https://foo.com",
+				"creationInfo": {
+					"creators": [{"Creator": "Google LLC", "CreatorType": "Organization"}],
+					"created": "2025-04-08T01:25:25Z"
+				}
+			}`,
+			expected: []testutil.FailedTopLevelCheck{
+				{
+					Name:  "Check that the SBOM has the correct SPDXIdentifier",
 					Specs: []string{"SPDX"},
 				},
 			},

--- a/pkg/checkers/common/common.go
+++ b/pkg/checkers/common/common.go
@@ -67,9 +67,14 @@ func SBOMHasSPDXIdentifier(
 	spec string,
 ) []*types.NonConformantField {
 	issues := make([]*types.NonConformantField, 0)
-	if doc.SPDXIdentifier == "" {
-		issue := types.CreateFieldError(types.SPDXID, spec)
-		issues = append(issues, issue)
+	if doc.SPDXIdentifier != "DOCUMENT" {
+		issues = append(issues, &types.NonConformantField{
+			Error: &types.FieldError{
+				ErrorType: "wrongValue",
+				ErrorMsg:  "SPDXID must be SPDXRef-Document",
+			},
+			ReportedBySpec: []string{spec},
+		})
 	}
 	return issues
 }

--- a/pkg/checkers/spdx/spdx.go
+++ b/pkg/checkers/spdx/spdx.go
@@ -45,7 +45,7 @@ func (spdxChecker *SPDXChecker) InitChecks() {
 			Impl: common.SBOMHasDataLicense,
 		},
 		{
-			Name: "Check that the SBOM has an SPDXIdentifier",
+			Name: "Check that the SBOM has the correct SPDXIdentifier",
 			Impl: common.SBOMHasSPDXIdentifier,
 		},
 		{


### PR DESCRIPTION
Previously, it was not checked that the field was `SPDXRef-DOCUMENT`.