### PR TITLE
Rename, document, and test the Google name, data license, and SPDX checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,24 @@ This is a package-level check that passes if either of the following are true:
 - the [Package Verification Code](https://spdx.github.io/spdx-spec/v2.3/package-information/#79-package-verification-code-field) field is missing
 - the [Package Verification Code](https://spdx.github.io/spdx-spec/v2.3/package-information/#79-package-verification-code-field) field is present and the [Files Analyzed](https://spdx.github.io/spdx-spec/v2.3/package-information/#78-files-analyzed-field) field is `true`
 
+### Google Style Guide
+
+name: `google`
+
+The Google SBOM Style Guide is similar to the SPDX requirements with a few additional restriction.
+
+#### Document Name
+
+This is a top-level check that passes if the [Document Name](https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#64-document-name-field) field is present and not empty.
+
+#### Data License
+
+This is a top-level check that passes if the [Data License](https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#62-data-license-field) field is `CC0-1.0`.
+
+#### Document SPDXID
+
+This is a top-level check that passes if the [Document SPDX Identifier](https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#63-spdx-identifier-field) field is `SPDXRef-DOCUMENT`.
+
 ## Disclaimer
 
 This is not an officially supported Google product. This project is not eligible for the [Google Open Source Software Vulnerability Rewards Program](https://bughunters.google.com/open-source-security).

--- a/pkg/checkers/common/common.go
+++ b/pkg/checkers/common/common.go
@@ -45,7 +45,7 @@ func SBOMHasSPDXVersion(
 	return issues
 }
 
-func SBOMHasDataLicense(
+func SBOMHasCorrectDataLicense(
 	doc *v23.Document,
 	spec string,
 ) []*types.NonConformantField {
@@ -62,7 +62,7 @@ func SBOMHasDataLicense(
 	return issues
 }
 
-func SBOMHasSPDXIdentifier(
+func SBOMHasCorrectSPDXIdentifier(
 	doc *v23.Document,
 	spec string,
 ) []*types.NonConformantField {

--- a/pkg/checkers/google/google.go
+++ b/pkg/checkers/google/google.go
@@ -34,54 +34,64 @@ type GoogleChecker struct {
 func (googleChecker *GoogleChecker) InitChecks() {
 	topLevelChecks := []*types.TopLevelCheck{
 		{
+			// needs to be updated to check for spdx 2.3
 			Name: "Check that the SBOM has an SPDX version",
 			Impl: common.SBOMHasSPDXVersion,
 		},
 		{
-			Name: "Check that the SBOM has a data license",
-			Impl: common.SBOMHasDataLicense,
+			Name: "Check that the data license is correct",
+			Impl: common.SBOMHasCorrectDataLicense,
 		},
 		{
-			Name: "Check that the SBOM has an SPDXIdentifier",
-			Impl: common.SBOMHasSPDXIdentifier,
+			Name: "Check that the SBOM has the correct SPDX Identifier",
+			Impl: common.SBOMHasCorrectSPDXIdentifier,
 		},
 		{
 			Name: "Check that the SBOM has a Document Name",
 			Impl: common.SBOMHasDocumentName,
 		},
 		{
+			// this needs to be updated to check for google specific url
 			Name: "Check that the SBOM has a Document Namespace",
 			Impl: common.SBOMHasValidDocumentNamespace,
 		},
 		{
+			// this is redundant given the following check
 			Name: "Check that the SBOM has at least one creator",
 			Impl: common.SBOMHasAtLeastOneCreator,
 		},
 		{
+			// this should be split into separate timestamp and creator checks
 			Name: "Check that the SBOMs creator is formatted correctly",
 			Impl: common.SBOMHasCorrectCreationInfo,
 		},
-		{
-			Name: "Check the SBOMs other licensing fields",
-			Impl: OtherLicensingInformationFields,
-		},
+		// This check needs to be updated. The OtherLicensingInformation section is
+		// not strictly required.
+		//		{
+		//			Name: "Check the SBOMs other licensing fields",
+		//			Impl: OtherLicensingInformationFields,
+		//		},
 	}
 	googleChecker.TopLevelChecks = topLevelChecks
 
 	packageLevelChecks := []*types.PackageLevelCheck{
 		{
+			// this needs to be tested
 			Name: "Check that SBOM packages have a name",
 			Impl: common.MustHaveName,
 		},
 		{
+			// this needs to be tested
 			Name: "Check that SBOM packages' ID is correctly formatted",
 			Impl: common.CheckSPDXID,
 		},
 		{
+			// this needs to be renamed to CheckPackageSupplier and the implementation simplified.
 			Name: "Check that SBOM packages have specified the supplier as Google",
 			Impl: CheckPackageOriginator,
 		},
 		{
+			// this needs to be updated to check that a custom license text is used
 			Name: "Check that SBOM packages have not left both PackageLicenseConcluded and PackageLicenseInfoFromFiles empty",
 			Impl: CheckConcludedLicense,
 		},

--- a/pkg/checkers/spdx/spdx.go
+++ b/pkg/checkers/spdx/spdx.go
@@ -41,11 +41,11 @@ func (spdxChecker *SPDXChecker) InitChecks() {
 		},
 		{
 			Name: "Check that the data license is correct",
-			Impl: common.SBOMHasDataLicense,
+			Impl: common.SBOMHasCorrectDataLicense,
 		},
 		{
 			Name: "Check that the SBOM has the correct SPDXIdentifier",
-			Impl: common.SBOMHasSPDXIdentifier,
+			Impl: common.SBOMHasCorrectSPDXIdentifier,
 		},
 		{
 			Name: "Check that the SBOM has a Document Name",


### PR DESCRIPTION
- The data license check is renamed to reflect that a specific value is required
- The document SPDXID check is renamed to reflect that a specific value is required