### PR TITLE
Reject SBOMs that are not SPDX v2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ A tool to check the conformance of SBOMs to specifications. A checker for the NT
 > [!NOTE]  
 > This library also contains a checker for the Google Style Guide, but it is not yet ready for use.
 
+> [!NOTE]  
+> This library only supports SPDX v2.3 and JSON encoded SBOMs.
+
 ## How to use
 
 sbom-conformance is a library and a CLI.
@@ -33,11 +36,9 @@ import (
 checker := base.NewChecker(base.WithGoogleChecker(),
                            base.WithEOChecker(),
                            base.WithSPDXChecker())
-
+checker.SetSBOM(sbom)
 checker.RunChecks()
-
 results := checker.Results()
-
 ```
 
 You can choose any of the supported specs.
@@ -141,10 +142,6 @@ This is a top-level check that passes if the [Document Namespace](https://spdx.g
 #### Document SPDXID
 
 This is a top-level check that passes if the [Document SPDX Identifier](https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#63-spdx-identifier-field) field is `SPDXRef-DOCUMENT`.
-
-#### SPDX Version
-
-This is a top-level check that passes if the [SPDX Version](https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#61-spdx-version-field) is present and conforms to `SPDX-M.N`.
 
 #### Creator
 

--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func main() {
 		panic(fmt.Errorf("error opening File: %w", err))
 	}
 	defer file.Close()
-	checker, err = checker.SetSBOM(file)
+	err = checker.SetSBOM(file)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/checkers/common/common.go
+++ b/pkg/checkers/common/common.go
@@ -39,7 +39,7 @@ func SBOMHasSPDXVersion(
 ) []*types.NonConformantField {
 	issues := make([]*types.NonConformantField, 0)
 	if doc.SPDXVersion == "" {
-		issue := types.CreateFieldError(types.SPDXVersion, spec)
+		issue := types.CreateWronglyFormattedFieldError(types.SPDXVersion, spec)
 		issues = append(issues, issue)
 	}
 	return issues
@@ -51,13 +51,8 @@ func SBOMHasCorrectDataLicense(
 ) []*types.NonConformantField {
 	issues := make([]*types.NonConformantField, 0)
 	if doc.DataLicense != "CC0-1.0" {
-		issues = append(issues, &types.NonConformantField{
-			Error: &types.FieldError{
-				ErrorType: "wrongValue",
-				ErrorMsg:  "DataLicense must be CC0-1.0",
-			},
-			ReportedBySpec: []string{spec},
-		})
+		issue := types.CreateWrongValueFieldError(types.DataLicense, "SPDXRef-DOCUMENT", spec)
+		issues = append(issues, issue)
 	}
 	return issues
 }
@@ -68,13 +63,8 @@ func SBOMHasCorrectSPDXIdentifier(
 ) []*types.NonConformantField {
 	issues := make([]*types.NonConformantField, 0)
 	if doc.SPDXIdentifier != "DOCUMENT" {
-		issues = append(issues, &types.NonConformantField{
-			Error: &types.FieldError{
-				ErrorType: "wrongValue",
-				ErrorMsg:  "SPDXID must be SPDXRef-Document",
-			},
-			ReportedBySpec: []string{spec},
-		})
+		issue := types.CreateWrongValueFieldError(types.SPDXID, "SPDXRef-DOCUMENT", spec)
+		issues = append(issues, issue)
 	}
 	return issues
 }

--- a/pkg/checkers/google/google.go
+++ b/pkg/checkers/google/google.go
@@ -34,11 +34,6 @@ type GoogleChecker struct {
 func (googleChecker *GoogleChecker) InitChecks() {
 	topLevelChecks := []*types.TopLevelCheck{
 		{
-			// needs to be updated to check for spdx 2.3
-			Name: "Check that the SBOM has an SPDX version",
-			Impl: common.SBOMHasSPDXVersion,
-		},
-		{
 			Name: "Check that the data license is correct",
 			Impl: common.SBOMHasCorrectDataLicense,
 		},

--- a/pkg/checkers/spdx/spdx.go
+++ b/pkg/checkers/spdx/spdx.go
@@ -36,10 +36,6 @@ type SPDXChecker struct {
 func (spdxChecker *SPDXChecker) InitChecks() {
 	topLevelChecks := []*types.TopLevelCheck{
 		{
-			Name: "Check that the SBOM has a valid SPDX version",
-			Impl: common.SBOMHasSPDXVersion,
-		},
-		{
 			Name: "Check that the data license is correct",
 			Impl: common.SBOMHasCorrectDataLicense,
 		},

--- a/pkg/checkers/types/types.go
+++ b/pkg/checkers/types/types.go
@@ -82,6 +82,17 @@ type PkgResult struct {
 	Errors  []*NonConformantField `json:"errors,omitempty"`
 }
 
+func CreateWrongValueFieldError(field, expectedValue, spec string) *NonConformantField {
+	issue := &NonConformantField{
+		Error: &FieldError{
+			ErrorType: "wrongValue",
+			ErrorMsg:  fmt.Sprintf("The field %q should be %q", field, expectedValue),
+		},
+		ReportedBySpec: []string{spec},
+	}
+	return issue
+}
+
 func CreateFieldError(field, spec string) *NonConformantField {
 	issue := &NonConformantField{
 		Error: &FieldError{

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -16,10 +16,18 @@
 package testutil
 
 import (
+	"fmt"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/sbom-conformance/pkg/checkers/types"
 )
+
+type BadReader struct{}
+
+func (BadReader) Read(p []byte) (int, error) {
+	return 0, fmt.Errorf("BadReader error") //nolint:err113
+}
 
 // FailedTopLevelCheck represents a check that has failed.
 //


### PR DESCRIPTION
Instead of adding SPDX version as a check in one of the specification, the `SetSBOM` now returns error if it is now `SPDX-2.3`. This is much simpler to do than adding it as a check, and also is reasonable to do because the library is a checker for v2.3.

Additionally, 
- a helper function `CreateWrongValueFieldError` to create issues is also added.
- `SetSBOM` is simplified.
- support for yaml and tagvalue is removed.