### PR TITLE
Fix, document, test Google Other License Information check

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ This is a top-level check that passes if, for each entry in the [Other Licensing
 - the [License Identifier](https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/#101-license-identifier-field) field is unique among all entries
 - the [Extracted Text Field](https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/#102-extracted-text-field) is present and not empty
 
+The licenses are not checked against the [SPDX license list](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-list/).
+
 #### Data License
 
 This is a top-level check that passes if the [Data License](https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#62-data-license-field) field is `CC0-1.0`.
@@ -213,6 +215,13 @@ This is a top-level check that passes if the [Creator](https://spdx.github.io/sp
 #### Created
 
 This is a top-level check that passes if the [Created](https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#69-created-field) field is present and conforms to `YYYY-MM-DDThh:mm:ssZ`.
+
+#### Other License Information
+
+This is a top-level check that passes if, for each entry in the [Other Licensing Information ](https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/) section, all of the following are true:
+- the [License Identifier](https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/#101-license-identifier-field) field is present and conforms to `LicenseRef-<idstring>` where `idstring` only contains letters, numbers, `.`, and/or `-`
+- the [License Identifier](https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/#101-license-identifier-field) field is unique among all entries
+- the [Extracted Text Field](https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/#102-extracted-text-field) is present and not empty
 
 ## Disclaimer
 

--- a/pkg/checkers/base/base_test.go
+++ b/pkg/checkers/base/base_test.go
@@ -877,6 +877,188 @@ func TestGoogleTopLevelChecks(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Other Licensing Info section is conformant",
+			sbom: `{
+				"spdxVersion": "SPDX-2.3",
+				"dataLicense": "CC0-1.0",
+				"name": "SimpleSBOM",
+				"documentNamespace": "https://spdx.google/cf736fd8-ceec-4cb5-b1aa-cb40ef942f18",
+				"SPDXID": "SPDXRef-DOCUMENT",
+				"creationInfo": {
+					"creators": ["Organization: Google LLC", "Tool: some-tool"],
+					"created": "2025-04-08T01:25:25Z"
+				},
+				"hasExtractedLicensingInfos": [
+					{
+						"licenseId": "LicenseRef-foo.abc123-.XYZ",
+						"extractedText": "foo license"
+					},
+					{
+						"licenseId": "LicenseRef-bar",
+						"extractedText": "bar license"
+					}
+				]
+			}`,
+		},
+		{
+			name: "Licensing Info section is not conformant because of a missing licenseId",
+			sbom: `{
+				"spdxVersion": "SPDX-2.3",
+				"dataLicense": "CC0-1.0",
+				"name": "SimpleSBOM",
+				"documentNamespace": "https://spdx.google/cf736fd8-ceec-4cb5-b1aa-cb40ef942f18",
+				"SPDXID": "SPDXRef-DOCUMENT",
+				"creationInfo": {
+					"creators": ["Organization: Google LLC", "Tool: some-tool"],
+					"created": "2025-04-08T01:25:25Z"
+				},
+				"hasExtractedLicensingInfos": [
+					{
+						"extractedText": "foo license"
+					}
+				]
+			}`,
+			expected: []testutil.FailedTopLevelCheck{
+				{
+					Name:  "Check that Other Licensing Information section is conformant",
+					Specs: []string{"Google"},
+				},
+			},
+		},
+		{
+			name: "Licensing Info section is not conformant because of a missing license text",
+			sbom: `{
+				"spdxVersion": "SPDX-2.3",
+				"dataLicense": "CC0-1.0",
+				"name": "SimpleSBOM",
+				"documentNamespace": "https://spdx.google/cf736fd8-ceec-4cb5-b1aa-cb40ef942f18",
+				"SPDXID": "SPDXRef-DOCUMENT",
+				"creationInfo": {
+					"creators": ["Organization: Google LLC", "Tool: some-tool"],
+					"created": "2025-04-08T01:25:25Z"
+				},
+				"hasExtractedLicensingInfos": [
+					{
+						"licenseId": "LicenseRef-foo"
+					}
+				]
+			}`,
+			expected: []testutil.FailedTopLevelCheck{
+				{
+					Name:  "Check that Other Licensing Information section is conformant",
+					Specs: []string{"Google"},
+				},
+			},
+		},
+		{
+			name: "Licensing Info section is not conformant because of an empty license text",
+			sbom: `{
+				"spdxVersion": "SPDX-2.3",
+				"dataLicense": "CC0-1.0",
+				"name": "SimpleSBOM",
+				"documentNamespace": "https://spdx.google/cf736fd8-ceec-4cb5-b1aa-cb40ef942f18",
+				"SPDXID": "SPDXRef-DOCUMENT",
+				"creationInfo": {
+					"creators": ["Organization: Google LLC", "Tool: some-tool"],
+					"created": "2025-04-08T01:25:25Z"
+				},
+				"hasExtractedLicensingInfos": [
+					{
+						"licenseId": "LicenseRef-foo",
+						"extractedText": ""
+					}
+				]
+			}`,
+			expected: []testutil.FailedTopLevelCheck{
+				{
+					Name:  "Check that Other Licensing Information section is conformant",
+					Specs: []string{"Google"},
+				},
+			},
+		},
+		{
+			name: "Licensing Info section is not conformant because licenseId is missing the idstring",
+			sbom: `{
+				"spdxVersion": "SPDX-2.3",
+				"dataLicense": "CC0-1.0",
+				"name": "SimpleSBOM",
+				"documentNamespace": "https://spdx.google/cf736fd8-ceec-4cb5-b1aa-cb40ef942f18",
+				"SPDXID": "SPDXRef-DOCUMENT",
+				"creationInfo": {
+					"creators": ["Organization: Google LLC", "Tool: some-tool"],
+					"created": "2025-04-08T01:25:25Z"
+				},
+				"hasExtractedLicensingInfos": [
+					{
+						"licenseId": "LicenseRef-",
+						"extractedText": "xyz"
+					}
+				]
+			}`,
+			expected: []testutil.FailedTopLevelCheck{
+				{
+					Name:  "Check that Other Licensing Information section is conformant",
+					Specs: []string{"Google"},
+				},
+			},
+		},
+		{
+			name: "Licensing Info section is not conformant because licenseId has invalid chars",
+			sbom: `{
+				"spdxVersion": "SPDX-2.3",
+				"dataLicense": "CC0-1.0",
+				"name": "SimpleSBOM",
+				"documentNamespace": "https://spdx.google/cf736fd8-ceec-4cb5-b1aa-cb40ef942f18",
+				"SPDXID": "SPDXRef-DOCUMENT",
+				"creationInfo": {
+					"creators": ["Organization: Google LLC", "Tool: some-tool"],
+					"created": "2025-04-08T01:25:25Z"
+				},
+				"hasExtractedLicensingInfos": [
+					{
+						"licenseId": "LicenseRef-a_a",
+						"extractedText": "foo"
+					}
+				]
+			}`,
+			expected: []testutil.FailedTopLevelCheck{
+				{
+					Name:  "Check that Other Licensing Information section is conformant",
+					Specs: []string{"Google"},
+				},
+			},
+		},
+		{
+			name: "Licensing Info section is not conformant licenseId is not unique",
+			sbom: `{
+				"spdxVersion": "SPDX-2.3",
+				"dataLicense": "CC0-1.0",
+				"name": "SimpleSBOM",
+				"documentNamespace": "https://spdx.google/cf736fd8-ceec-4cb5-b1aa-cb40ef942f18",
+				"SPDXID": "SPDXRef-DOCUMENT",
+				"creationInfo": {
+					"creators": ["Organization: Google LLC", "Tool: some-tool"],
+					"created": "2025-04-08T01:25:25Z"
+				},
+				"hasExtractedLicensingInfos": [
+					{
+						"licenseId": "LicenseRef-a",
+						"extractedText": "foo"
+					},
+					{
+						"licenseId": "LicenseRef-a",
+						"extractedText": "foo"
+					}
+				]
+			}`,
+			expected: []testutil.FailedTopLevelCheck{
+				{
+					Name:  "Check that Other Licensing Information section is conformant",
+					Specs: []string{"Google"},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1434,7 +1616,8 @@ func TestSPDXTopLevelChecks(t *testing.T) {
 				},
 				"hasExtractedLicensingInfos": [
 					{
-						"licenseId": "LicenseRef-a_a"
+						"licenseId": "LicenseRef-a_a",
+						"extractedText": "foo"
 					}
 				]
 			}`,
@@ -3033,8 +3216,8 @@ func TestGoogleChecker(t *testing.T) {
 		t.Errorf("The 'Google' spec summary should be Conformant=true but was Conformant=%t\n",
 			results.Summary.SpecSummaries["Google"].Conformant)
 	}
-	if results.Summary.SpecSummaries["Google"].PassedChecks != 4 {
-		t.Errorf("The 'Google' spec summary should be PassedChecks=4 but was PassedChecks=%d\n",
+	if results.Summary.SpecSummaries["Google"].PassedChecks != 5 {
+		t.Errorf("The 'Google' spec summary should be PassedChecks=5 but was PassedChecks=%d\n",
 			results.Summary.SpecSummaries["Google"].PassedChecks)
 	}
 	if len(results.PkgResults) != 4 {

--- a/pkg/checkers/google/google.go
+++ b/pkg/checkers/google/google.go
@@ -57,12 +57,10 @@ func (googleChecker *GoogleChecker) InitChecks() {
 			Name: "Check that the SBOM's timestamp is conformant",
 			Impl: common.CheckCreatedIsConformant,
 		},
-		// This check needs to be updated. The OtherLicensingInformation section is
-		// not strictly required.
-		//		{
-		//			Name: "Check the SBOMs other licensing fields",
-		//			Impl: OtherLicensingInformationFields,
-		//		},
+		{
+			Name: "Check that Other Licensing Information section is conformant",
+			Impl: common.CheckOtherLicensingInformationSection,
+		},
 	}
 	googleChecker.TopLevelChecks = topLevelChecks
 

--- a/pkg/checkers/spdx/spdx.go
+++ b/pkg/checkers/spdx/spdx.go
@@ -67,7 +67,7 @@ func (spdxChecker *SPDXChecker) InitChecks() {
 			// This check could be lowered to a per-license level, like packages,
 			// but it requires changes to the API and it's probably not a priority.
 			Name: "Check that Other Licensing Information section is conformant",
-			Impl: CheckOtherLicensingInformationSection,
+			Impl: common.CheckOtherLicensingInformationSection,
 		},
 	}
 	spdxChecker.TopLevelChecks = topLevelChecks


### PR DESCRIPTION
This PR updates the other license information check to not make it required and to not require CrossReferences. We don't make it required because if all packages don't have licenses (or they are NOASSERTION/NONE), then there's nothing to add to this section.