### PR TITLE
Remove second slash from Google doc namespace

### DIFF
--- a/pkg/checkers/google/checks.go
+++ b/pkg/checkers/google/checks.go
@@ -81,7 +81,7 @@ func SBOMHasGoogleDocumentNamespace(
 	if !found || uuid.Validate(after) != nil {
 		issue := types.CreateWrongValueFieldError(
 			types.DocumentNamespace,
-			fmt.Sprintf("%s/<uuid>", googleDocNamespacePrefix),
+			fmt.Sprintf("%s<uuid>", googleDocNamespacePrefix),
 			spec,
 		)
 		issues = append(issues, issue)


### PR DESCRIPTION
The prefix already ends with `/`; the error currently reads as `The field "Document Namespace" should be "https://spdx.google//<uuid>".`