### PR TITLE
Add constants for check names

### DIFF
--- a/pkg/checkers/eo/eo.go
+++ b/pkg/checkers/eo/eo.go
@@ -21,6 +21,19 @@ import (
 	v23 "github.com/spdx/tools-golang/spdx/v2/v2_3"
 )
 
+const (
+	// top-level checks.
+	HasAtLeastOneCreator = "Check that the SBOM has at least one creator"
+	HasTimestamp         = "Check that the SBOM has a timestamp"
+	HasRelationships     = "Check that each SBOM package has a relationship"
+
+	// package-level checks.
+	PackageHasName              = "Check that SBOM packages have a name"
+	PackageHasValidVersion      = "Check that SBOM packages have a valid version"
+	PackageHasSupplier          = "Check that the package has a supplier"
+	PackageHasExternalReference = "Check that SBOM packages have external references"
+)
+
 type EOChecker struct {
 	Name           string                      `json:"name"`
 	TopLevelChecks []*types.TopLevelCheck      `json:"topLevelChecks"`
@@ -34,15 +47,15 @@ type EOChecker struct {
 func (eoChecker *EOChecker) InitChecks() {
 	topLevelChecks := []*types.TopLevelCheck{
 		{
-			Name: "Check that the SBOM has at least one creator",
+			Name: HasAtLeastOneCreator,
 			Impl: common.SBOMHasAtLeastOneCreator,
 		},
 		{
-			Name: "Check that the SBOM has a timestamp",
+			Name: HasTimestamp,
 			Impl: MustHaveTimestamp,
 		},
 		{
-			Name: "Check that each SBOM package has a relationship",
+			Name: HasRelationships,
 			Impl: checkPackagesHaveRelationships,
 		},
 	}
@@ -50,19 +63,19 @@ func (eoChecker *EOChecker) InitChecks() {
 
 	packageLevelChecks := []*types.PackageLevelCheck{
 		{
-			Name: "Check that SBOM packages have a name",
+			Name: PackageHasName,
 			Impl: common.MustHaveName,
 		},
 		{
-			Name: "Check that SBOM packages have a valid version",
+			Name: PackageHasValidVersion,
 			Impl: MustHaveValidVersion,
 		},
 		{
-			Name: "Check that the package has a supplier",
+			Name: PackageHasSupplier,
 			Impl: MustHaveSupplier,
 		},
 		{
-			Name: "Check that SBOM packages have external references",
+			Name: PackageHasExternalReference,
 			Impl: MustHaveExternalReferences,
 		},
 	}

--- a/pkg/checkers/google/google.go
+++ b/pkg/checkers/google/google.go
@@ -21,6 +21,23 @@ import (
 	v23 "github.com/spdx/tools-golang/spdx/v2/v2_3"
 )
 
+const (
+	// top-level checks
+	HasCorrectDataLicense                  = "Check that the data license is correct"
+	HasCorrectDocumentSPDXIdentifier       = "Check that the SBOM has the correct SPDX Identifier"
+	HasDocumentName                        = "Check that the SBOM has a Document Name"
+	HasGoogleDocumentNamespace             = "Check that the SBOM has a Google Document Namespace"
+	HasConformantCreators                  = "Check that the SBOM has a Google Creator, a Tool creator, and no Person creator"
+	HasConformantTimestamp                 = "Check that the SBOM's timestamp is conformant"
+	HasConformantOtherLicensingInformation = "Check that Other Licensing Information section is conformant"
+
+	// package-level checks
+	PackageHasName                 = "Check that SBOM packages have a name"
+	PackageHasConformantSPDXID     = "Check that SBOM packages' ID is present and conformant"
+	PackageSupplierIsValid         = "Check that SBOM packages have a valid supplier"
+	PackageLicenseInfoIsConformant = "Check that SBOM packages' licenses are conformant"
+)
+
 type GoogleChecker struct {
 	Name           string                      `json:"name"`
 	TopLevelChecks []*types.TopLevelCheck      `json:"topLevelChecks"`
@@ -34,31 +51,31 @@ type GoogleChecker struct {
 func (googleChecker *GoogleChecker) InitChecks() {
 	topLevelChecks := []*types.TopLevelCheck{
 		{
-			Name: "Check that the data license is correct",
+			Name: HasCorrectDataLicense,
 			Impl: common.SBOMHasCorrectDataLicense,
 		},
 		{
-			Name: "Check that the SBOM has the correct SPDX Identifier",
+			Name: HasCorrectDocumentSPDXIdentifier,
 			Impl: common.SBOMHasCorrectSPDXIdentifier,
 		},
 		{
-			Name: "Check that the SBOM has a Document Name",
+			Name: HasDocumentName,
 			Impl: common.SBOMHasDocumentName,
 		},
 		{
-			Name: "Check that the SBOM has a Google Document Namespace",
+			Name: HasGoogleDocumentNamespace,
 			Impl: SBOMHasGoogleDocumentNamespace,
 		},
 		{
-			Name: "Check that the SBOM has a Google Creator, a Tool creator, and no Person creator",
+			Name: HasConformantCreators,
 			Impl: SBOMHasGoogleCreators,
 		},
 		{
-			Name: "Check that the SBOM's timestamp is conformant",
+			Name: HasConformantTimestamp,
 			Impl: common.CheckCreatedIsConformant,
 		},
 		{
-			Name: "Check that Other Licensing Information section is conformant",
+			Name: HasConformantOtherLicensingInformation,
 			Impl: common.CheckOtherLicensingInformationSection,
 		},
 	}
@@ -66,19 +83,19 @@ func (googleChecker *GoogleChecker) InitChecks() {
 
 	packageLevelChecks := []*types.PackageLevelCheck{
 		{
-			Name: "Check that SBOM packages have a name",
+			Name: PackageHasName,
 			Impl: common.MustHaveName,
 		},
 		{
-			Name: "Check that SBOM packages' ID is present and conformant",
+			Name: PackageHasConformantSPDXID,
 			Impl: common.CheckSPDXID,
 		},
 		{
-			Name: "Check that SBOM packages have a valid supplier",
+			Name: PackageSupplierIsValid,
 			Impl: CheckPackageSupplier,
 		},
 		{
-			Name: "Check that SBOM packages' licenses are conformant",
+			Name: PackageLicenseInfoIsConformant,
 			Impl: CheckPackageLicenses,
 		},
 	}

--- a/pkg/checkers/google/google.go
+++ b/pkg/checkers/google/google.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	// top-level checks
+	// top-level checks.
 	HasCorrectDataLicense                  = "Check that the data license is correct"
 	HasCorrectDocumentSPDXIdentifier       = "Check that the SBOM has the correct SPDX Identifier"
 	HasDocumentName                        = "Check that the SBOM has a Document Name"
@@ -31,7 +31,7 @@ const (
 	HasConformantTimestamp                 = "Check that the SBOM's timestamp is conformant"
 	HasConformantOtherLicensingInformation = "Check that Other Licensing Information section is conformant"
 
-	// package-level checks
+	// package-level checks.
 	PackageHasName                 = "Check that SBOM packages have a name"
 	PackageHasConformantSPDXID     = "Check that SBOM packages' ID is present and conformant"
 	PackageSupplierIsValid         = "Check that SBOM packages have a valid supplier"

--- a/pkg/checkers/google/google.go
+++ b/pkg/checkers/google/google.go
@@ -21,6 +21,7 @@ import (
 	v23 "github.com/spdx/tools-golang/spdx/v2/v2_3"
 )
 
+//nolint:lll
 const (
 	// top-level checks.
 	HasCorrectDataLicense                  = "Check that the data license is correct"

--- a/pkg/checkers/spdx/spdx.go
+++ b/pkg/checkers/spdx/spdx.go
@@ -21,6 +21,24 @@ import (
 	v23 "github.com/spdx/tools-golang/spdx/v2/v2_3"
 )
 
+const (
+	// top-level checks
+	HasCorrectDataLicense                  = "Check that the data license is correct"
+	HasCorrectDocumentSPXIdentifier        = "Check that the SBOM has the correct SPDXIdentifier"
+	HasDocumentName                        = "Check that the SBOM has a Document Name"
+	HasConformantDocumentNamespace         = "Check that the SBOM has a valid Document Namespace"
+	HasConformantCreators                  = "Check that the SBOM has at least one creator and that they are formatted correctly"
+	HasConformantTimestamp                 = "Check that the SBOM's timestamp is conformant"
+	HasUniqueSPDXIdentifiers               = "Check that the package SPDX identifiers are unique"
+	HasConformantOtherLicensingInformation = "Check that Other Licensing Information section is conformant"
+
+	// package-level checks
+	PackageHasName                   = "Check that SBOM packages have a name"
+	PackageHasConformantSPDXID       = "Check that SBOM packages' ID is present and conformant"
+	PackageFilesAnalyzedIsConformant = "Check that SBOM packages' filesAnalyzed is true if packageVerificationCode is present"
+	PackageHasDownloadLocation       = "Check that SBOM packages have a download location"
+)
+
 type SPDXChecker struct {
 	Name           string                     `json:"name"`
 	TopLevelChecks []*types.TopLevelCheck     `json:"topLevelChecks"`
@@ -36,37 +54,37 @@ type SPDXChecker struct {
 func (spdxChecker *SPDXChecker) InitChecks() {
 	topLevelChecks := []*types.TopLevelCheck{
 		{
-			Name: "Check that the data license is correct",
+			Name: HasCorrectDataLicense,
 			Impl: common.SBOMHasCorrectDataLicense,
 		},
 		{
-			Name: "Check that the SBOM has the correct SPDXIdentifier",
+			Name: HasCorrectDocumentSPXIdentifier,
 			Impl: common.SBOMHasCorrectSPDXIdentifier,
 		},
 		{
-			Name: "Check that the SBOM has a Document Name",
+			Name: HasDocumentName,
 			Impl: common.SBOMHasDocumentName,
 		},
 		{
-			Name: "Check that the SBOM has a valid Document Namespace",
+			Name: HasConformantDocumentNamespace,
 			Impl: common.SBOMHasValidDocumentNamespace,
 		},
 		{
-			Name: "Check that the SBOM has at least one creator and that they are formatted correctly",
+			Name: HasConformantCreators,
 			Impl: CheckCreatorIsConformant,
 		},
 		{
-			Name: "Check that the SBOM's timestamp is conformant",
+			Name: HasConformantTimestamp,
 			Impl: common.CheckCreatedIsConformant,
 		},
 		{
-			Name: "Check that the package SPDX identifiers are unique",
+			Name: HasUniqueSPDXIdentifiers,
 			Impl: CheckUniqueSPDXIdentifier,
 		},
 		{
 			// This check could be lowered to a per-license level, like packages,
 			// but it requires changes to the API and it's probably not a priority.
-			Name: "Check that Other Licensing Information section is conformant",
+			Name: HasConformantOtherLicensingInformation,
 			Impl: common.CheckOtherLicensingInformationSection,
 		},
 	}
@@ -74,19 +92,19 @@ func (spdxChecker *SPDXChecker) InitChecks() {
 
 	packageLevelChecks := []*types.PackageLevelCheck{
 		{
-			Name: "Check that SBOM packages have a name",
+			Name: PackageHasName,
 			Impl: common.MustHaveName,
 		},
 		{
-			Name: "Check that SBOM packages' ID is present and conformant",
+			Name: PackageHasConformantSPDXID,
 			Impl: common.CheckSPDXID,
 		},
 		{
-			Name: "Check that SBOM packages' filesAnalyzed is true if packageVerificationCode is present",
+			Name: PackageFilesAnalyzedIsConformant,
 			Impl: CheckFilesAnalyzed,
 		},
 		{
-			Name: "Check that SBOM packages have a download location",
+			Name: PackageHasDownloadLocation,
 			Impl: CheckDownloadLocation,
 		},
 	}

--- a/pkg/checkers/spdx/spdx.go
+++ b/pkg/checkers/spdx/spdx.go
@@ -21,6 +21,7 @@ import (
 	v23 "github.com/spdx/tools-golang/spdx/v2/v2_3"
 )
 
+//nolint:lll
 const (
 	// top-level checks.
 	HasCorrectDataLicense                  = "Check that the data license is correct"

--- a/pkg/checkers/spdx/spdx.go
+++ b/pkg/checkers/spdx/spdx.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	// top-level checks
+	// top-level checks.
 	HasCorrectDataLicense                  = "Check that the data license is correct"
 	HasCorrectDocumentSPXIdentifier        = "Check that the SBOM has the correct SPDXIdentifier"
 	HasDocumentName                        = "Check that the SBOM has a Document Name"
@@ -32,7 +32,7 @@ const (
 	HasUniqueSPDXIdentifiers               = "Check that the package SPDX identifiers are unique"
 	HasConformantOtherLicensingInformation = "Check that Other Licensing Information section is conformant"
 
-	// package-level checks
+	// package-level checks.
 	PackageHasName                   = "Check that SBOM packages have a name"
 	PackageHasConformantSPDXID       = "Check that SBOM packages' ID is present and conformant"
 	PackageFilesAnalyzedIsConformant = "Check that SBOM packages' filesAnalyzed is true if packageVerificationCode is present"


### PR DESCRIPTION
This will allow clients to reference individual checks without copying over the strings.