### PR TITLE
Include check name in check result deduplication

### DIFF
--- a/pkg/checkers/base/base.go
+++ b/pkg/checkers/base/base.go
@@ -601,7 +601,7 @@ func deduplicatePackageResults(mergedPacks []*types.PkgResult) []*types.PkgResul
 		for _, err := range pack.Errors {
 			hasDuplicateError := false
 			for _, e := range cleanedErrors {
-				if err.Error.ErrorMsg == e.Error.ErrorMsg {
+				if err.Error.ErrorMsg == e.Error.ErrorMsg && err.CheckName == e.CheckName {
 					// Only add the spec if we haven't already. Otherwise, there
 					// might be package results with duplicate specs
 					if !slices.Contains(e.ReportedBySpec, err.ReportedBySpec[0]) {

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -49,10 +49,24 @@ var FailedTopLevelCheckOpts []cmp.Option = []cmp.Option{
 	cmpopts.SortSlices(lessTopLevelCheck),
 }
 
+var PkgResultsOpts []cmp.Option = []cmp.Option{
+	cmpopts.EquateEmpty(),
+	cmpopts.SortSlices(func(package1, package2 *types.PkgResult) bool {
+		return package1.Package.SpdxID < package2.Package.SpdxID
+	}),
+	cmpopts.SortSlices(func(error1, error2 *types.NonConformantField) bool {
+		// All errors with the same ErrorMsg should have the same ErrorType
+		return error1.Error.ErrorMsg < error2.Error.ErrorMsg
+	}),
+	cmpopts.SortSlices(func(s1, s2 string) bool { return s1 < s2 }),
+}
+
 // ExtractFailedTopLevelChecks returns the failed checks in the input.
-func ExtractFailedTopLevelChecks(topLeveChecks []*types.TopLevelCheckResult) []FailedTopLevelCheck {
+func ExtractFailedTopLevelChecks(
+	topLevelChecks []*types.TopLevelCheckResult,
+) []FailedTopLevelCheck {
 	failedChecks := []FailedTopLevelCheck{}
-	for _, check := range topLeveChecks {
+	for _, check := range topLevelChecks {
 		if !check.Passed {
 			failedChecks = append(failedChecks, FailedTopLevelCheck{
 				Name:  check.Name,

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -63,7 +63,7 @@ func alreadyDeduplicated(
 	deduplicatedIssues []*DeduplicatedIssue,
 ) bool {
 	for _, iss := range deduplicatedIssues {
-		if iss.ErrorMessage == issue.Error.ErrorMsg {
+		if iss.ErrorMessage == issue.Error.ErrorMsg && iss.CheckName == issue.CheckName {
 			return true
 		}
 	}


### PR DESCRIPTION
This fixes a bug in which failed checks are dropped from the output.

The bug occurs because check results are currently deduplicated solely by error message. However, different checks can have the same error message (this is encouraged by reuse of [functions which generate the error messages](https://github.com/google/sbom-conformance/blob/25e1d0a3706cada5bb064e780f99a55e20370e1e/pkg/checkers/types/types.go#L138)). This PR expands the deduplication to include the check name as well. 